### PR TITLE
Build improvements

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+app/
+definitions/
+docs/
+tests/
+_build/tests
+gulpfile.js
+tsconfig.json

--- a/app/app.ts
+++ b/app/app.ts
@@ -1,5 +1,3 @@
-/// <reference path="../definitions/q/Q.d.ts"/>
-/// <reference path="../definitions/node/node.d.ts"/>
 import fs = require('fs');
 import path = require('path');
 import loader = require('./lib/loader');

--- a/app/exec/build-tasks-delete.ts
+++ b/app/exec/build-tasks-delete.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../definitions/q/Q.d.ts"/>
-
 import agentifm = require('vso-node-api/interfaces/TaskAgentInterfaces');
 import cmdm = require('../lib/tfcommand');
 import cm = require('../lib/common');

--- a/app/exec/build-tasks-upload.ts
+++ b/app/exec/build-tasks-upload.ts
@@ -1,6 +1,3 @@
-/// <reference path="../../definitions/q/Q.d.ts"/>
-/// <reference path="../../definitions/node/node.d.ts"/>
-
 import cmdm = require('../lib/tfcommand');
 import cm = require('../lib/common');
 import vm = require('../lib/jsonvalidate')

--- a/app/lib/connection.ts
+++ b/app/lib/connection.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../definitions/vso-node-api/vso-node-api.d.ts"/>
-
 import inputs = require('./inputs');
 import Q = require('q');
 import am = require('./auth');

--- a/app/lib/inputs.ts
+++ b/app/lib/inputs.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-/// <reference path="../../definitions/q/Q.d.ts" />
-
 import cm = require('./common');
 import os = require('os');
 import Q = require('q');

--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../definitions/q/Q.d.ts"/>
-
 import Q = require('q');
 var fs = require('fs');
 var shell = require('shelljs');

--- a/app/lib/loader.ts
+++ b/app/lib/loader.ts
@@ -1,6 +1,3 @@
-/// <reference path="../../definitions/node/node.d.ts"/>
-/// <reference path="../../definitions/colors/colors.d.ts"/>
-
 import fs = require('fs');
 import path = require('path');
 import cm = require('./common');

--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../definitions/vso-node-api/vso-node-api.d.ts"/>
-
 import cm = require('./common');
 import cnm = require('./connection');
 import apim = require('vso-node-api/WebApi');

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "type": "git",
     "url": "https://github.com/Microsoft/tfs-cli"
   },
-  "main": "./tfx-cli.js",
+  "main": "./_build/app/tfx-cli.js",
   "preferGlobal": true,
   "bin": {
-    "tfx": "./tfx-cli.js"
+    "tfx": "./_build/app/tfx-cli.js"
   },
   "scripts": {
     "test": "gulp test"
@@ -30,8 +30,9 @@
   "devDependencies": {
     "del": "^1.2.0",
     "gulp": "^3.9.0",
+    "gulp-filter": "^3.0.1",
     "gulp-mocha": "2.0.0",
-    "gulp-tsc": "^0.10.1",
+    "gulp-tsb": "^1.5.1",
     "minimatch": "^2.0.8",
     "mocha": "^2.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "tfx": "./_build/app/tfx-cli.js"
   },
   "scripts": {
+    "prepublish": "gulp build",
     "test": "gulp test"
   },
   "dependencies": {

--- a/tests/commandline.ts
+++ b/tests/commandline.ts
@@ -1,6 +1,3 @@
-/// <reference path="../definitions/mocha.d.ts"/>
-/// <reference path="../definitions/q/Q.d.ts"/>
-/// <reference path="../definitions/node/node.d.ts"/>
 import Q = require('q');
 import assert = require('assert');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "ES5",
+		"declaration": false
+	}
+}


### PR DESCRIPTION
This PR does a few improvements around the building:

* **Use [`gulp-tsb`](https://www.npmjs.com/package/gulp-tsb)**. It's simply a better approach at using TypeScript with gulp. We use it to develop VSCode.
* **Add `tsconfig.json`**. This serves both as a configuration for the compiler used in gulp, as well as a configuration for VS Code (and other tools), when editing the project. This enables dropping the nasty `/// <reference...` snippets.
* **Simplify the gulp tasks**. Instead of having multiple, interdependent tasks, just have one that does the build all at once. Gulp streams here help us out in a very nice way.
* **Fix `npm link`**. Currently it is not possible to run `npm link` because `package.json` points to `./tfx-cli.js`, which never exists at development time, since `package.json` is copied to the `_build` directory as part of the build step.
* **Add `.npmignore`**. So we can take away all the cruft from the node module, once it's published to npm.
* **Add `prepublish` step to `package.json`**. So `gulp build` gets run everything someone runs `npm link` or `npm publish`.