### PR TITLE
Add Logout and Status commands

### DIFF
--- a/app/exec/logout.ts
+++ b/app/exec/logout.ts
@@ -1,0 +1,58 @@
+import cmdm = require('../lib/tfcommand');
+import cm = require('../lib/common');
+import Q = require('q');
+import cam = require('../lib/diskcache');
+var trace = require('../lib/trace');
+
+export function describe(): string {
+    return 'Logs out of the logged in collection, if one is present';
+}
+
+export function getCommand(): cmdm.TfCommand {
+    // this just offers description for help and to offer sub commands
+    return new Logout();
+}
+
+// requires auth, connect etc...
+export var isServerOperation: boolean = false;
+
+// unless you have a good reason, should not hide
+export var hideBanner: boolean = false;
+
+export class Logout extends cmdm.TfCommand {
+    public exec(args: string[], options: cm.IOptions): Q.Promise<string> {
+        trace('Logout.exec');
+        var defer = Q.defer();
+
+        var cache: cam.DiskCache = new cam.DiskCache('tfx');
+
+        trace('Checking for a cached connection...');
+        cache.itemExists('cache', 'connection')
+        .then((result) => {
+            if (result) {
+                cache.getItem('cache', 'connection')
+                .then((url) => {
+                    if (url) {
+                        trace('Found a cached connection. Removing it.');
+                        cache.setItem('cache', 'connection', '');
+                        defer.resolve("Logged out successfully");
+                    }
+                    else {
+                        trace('No cached connection to remove.');
+                        defer.resolve("No cached connection to log out of");
+                    }
+                })
+            }
+            else {
+                trace('No cached connection to remove.');
+                defer.resolve("No cached connection to log out of");
+            }
+        });
+
+        return <Q.Promise<string>>defer.promise;
+    }
+
+    public output(status: string): void {
+        console.log(status);
+    }
+}

--- a/app/exec/status.ts
+++ b/app/exec/status.ts
@@ -36,27 +36,36 @@ export class LoginStatus extends cmdm.TfCommand {
         var result: ILoginStatus = {url: null, creds: null};
 
         trace('Loading cached connection url');
-        cache.getItem('cache', 'connection')
-        .then((url) => {
-            if (url) {
-                result.url = url;
-                trace('Found url ' + url);
-                trace('Looking for cached credentials for ' + url);
-                return cs.credentialExists(url, 'allusers')
-                .then((result) => {
-                    if (result)
-                    {
-                        trace('Found credentials in the cache');
-                        return cs.getCredential(url, 'allusers');
+        cache.itemExists('cache', 'connection')
+        .then((exists) => {
+            if (exists) {
+                cache.getItem('cache', 'connection')
+                .then((url) => {
+                    if (url) {
+                        result.url = url;
+                        trace('Found url ' + url);
+                        trace('Looking for cached credentials for ' + url);
+                        return cs.credentialExists(url, 'allusers')
+                        .then((result) => {
+                            if (result)
+                            {
+                                trace('Found credentials in the cache');
+                                return cs.getCredential(url, 'allusers');
+                            }
+                            trace('Did not find credentials in the cache');
+                        })
+                        .then((creds) => {
+                            result.creds = creds;
+                            defer.resolve(result);
+                        });
                     }
-                    trace('Did not find credentials in the cache');
+                    else {
+                        defer.resolve(result);
+                    }
                 })
-                .then((creds) => {
-                    result.creds = creds;
-                    defer.resolve(result);
-                });
             }
             else {
+                trace('No cached connection file found');
                 defer.resolve(result);
             }
         });
@@ -67,14 +76,14 @@ export class LoginStatus extends cmdm.TfCommand {
     public output(status: ILoginStatus): void {
         if (status.url) {
             if (status.creds) {
-                console.log("Logged into to collection '" + status.url + "' with credentials '" + status.creds + "'.");
+                console.log("Logged in to collection '" + status.url + "' with credentials '" + status.creds + "'.");
             }
             else {
-                console.log("Logged into to collection '" + status.url + "', but no credentials are cached");
+                console.log("Logged in to collection '" + status.url + "', but no credentials are cached");
             }
         }
         else {
-            console.log("You are not logged into to any collection");
+            console.log("You are not logged in to any collection");
         }
     }
 }

--- a/app/exec/status.ts
+++ b/app/exec/status.ts
@@ -1,0 +1,80 @@
+import cmdm = require('../lib/tfcommand');
+import cm = require('../lib/common');
+import Q = require('q');
+import csm = require('../lib/credstore');
+import cam = require('../lib/diskcache');
+var trace = require('../lib/trace');
+
+export function describe(): string {
+    return 'prints the status of the logged in connection';
+}
+
+export function getCommand(): cmdm.TfCommand {
+    // this just offers description for help and to offer sub commands
+    return new LoginStatus();
+}
+
+// requires auth, connect etc...
+export var isServerOperation: boolean = false;
+
+// unless you have a good reason, should not hide
+export var hideBanner: boolean = false;
+
+export interface ILoginStatus {
+    url: string,
+    creds: string
+}
+
+export class LoginStatus extends cmdm.TfCommand {
+    public exec(args: string[], options: cm.IOptions): Q.Promise<ILoginStatus> {
+        trace('LoginStatus.exec');
+        var defer = Q.defer();
+
+        var cache: cam.DiskCache = new cam.DiskCache('tfx');
+        var cs: csm.ICredentialStore = csm.getCredentialStore('tfx');
+
+        var result: ILoginStatus = {url: null, creds: null};
+
+        trace('Loading cached connection url');
+        cache.getItem('cache', 'connection')
+        .then((url) => {
+            if (url) {
+                result.url = url;
+                trace('Found url ' + url);
+                trace('Looking for cached credentials for ' + url);
+                return cs.credentialExists(url, 'allusers')
+                .then((result) => {
+                    if (result)
+                    {
+                        trace('Found credentials in the cache');
+                        return cs.getCredential(url, 'allusers');
+                    }
+                    trace('Did not find credentials in the cache');
+                })
+                .then((creds) => {
+                    result.creds = creds;
+                    defer.resolve(result);
+                });
+            }
+            else {
+                defer.resolve(result);
+            }
+        });
+
+        return <Q.Promise<ILoginStatus>>defer.promise;
+    }
+
+    public output(status: ILoginStatus): void {
+        if (status.url) {
+            if (status.creds) {
+                console.log("Logged into to collection '" + status.url + "' with credentials '" + status.creds + "'.");
+            }
+            else {
+                console.log("Logged into to collection '" + status.url + "', but no credentials are cached");
+            }
+        }
+        else {
+            console.log("You are not logged into to any collection");
+        }
+    }
+}


### PR DESCRIPTION
tfx status will print out the status of the currently logged in connection, if there is one.

tfx logout will logout of the currently logged in connection if there is one. Logging out does not remove the cached credentials for that collection. This allows the user to continue using that collection by opting in on the command line with --collectionurl and using the cached credentials (via #48). It just causes server commands to not use a specific collection by default.

These two commands can be used in conjunction to help manage working with multiple accounts/collections. The general workflow would then be as follows when working with multiple accounts:

1) Log in to all accounts and cache the PATs
```
tfx login ...
tfx login ...
tfx login ...
```

2) Perform some work, and then attempt to do something with one of the accounts. Check which account you are currently logged in to before performing any actions
```
tfx status
```

3) If you want to be safe and not use any account by default (force each command to specify the collection to use explicitly), log out of the currently logged in account
```
tfx logout
```

4) Perform the action against the currently logged in account, or explicitly specify one on the command line if you are logged out or wish to override the logged in account
```
tfx build tasks upload .
tfx build tasks upload . --collectionurl https://myaccount.visualstudio.com/DefaultCollection
```

One potential improvement that could be made in addition to these new commands is that the login command could optionally continue using the cache PAT from the last time that account was logged in. This way, the user can switch back and forth between the active account without having to regenerate new PATs every time.