### PR TITLE
Fix login URI in README.md for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Currently supported credential types are Personal Access Tokens and basic auth.
 ~$ tfx login
 Copyright Microsoft Corporation
 
-> Service URL: https://marketplace.visualstudio.com (for extensions) https://youraccount.visualstudio.com/DefaultCollection (other)
+> Service URL: https://app.market.visualstudio.com (for extensions) https://youraccount.visualstudio.com/DefaultCollection (other)
 > Personal access token: 
 Logged in successfully
 ```


### PR DESCRIPTION
The login URI for extensions in the README should be https://app.market.visualstudio.com, otherwise users are still prompted for their token.