### PR TITLE
Adding Microsoft.VisualStudio.Services.Cloud as VSSExtension target

### DIFF
--- a/app/exec/extension/_lib/extension-composer-factory.ts
+++ b/app/exec/extension/_lib/extension-composer-factory.ts
@@ -19,6 +19,7 @@ export class ComposerFactory {
 		targets.forEach((target) => {
 			switch (target.id) {
 				case "Microsoft.VisualStudio.Services" :
+				case "Microsoft.VisualStudio.Services.Cloud" :
 					composers.push(new VSSExtensionComposer(settings));
 					break;
 				case "Microsoft.VisualStudio.Services.Integration" : 


### PR DESCRIPTION
Microsoft.VisualStudio.Services.Cloud will server as a VSSExtension target for extensions that only work for Team Services, and not for the onPrem Team Foundation Server. See https://www.visualstudio.com/en-us/integrate/extensions/develop/manifest