### PR TITLE
add build details and build delete, restore show to default settings

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,0 +1,7 @@
+[Dolphin]
+Timestamp=2016,3,6,20,54,51
+Version=3
+ViewMode=1
+
+[Settings]
+HiddenFilesShown=true

--- a/app/exec/build/delete.ts
+++ b/app/exec/build/delete.ts
@@ -1,0 +1,50 @@
+import { TfCommand } from "../../lib/tfcommand";
+import args = require("../../lib/arguments");
+import buildBase = require("./default");
+import buildClient = require("vso-node-api/BuildApi");
+import buildContracts = require("vso-node-api/interfaces/BuildInterfaces");
+import trace = require("../../lib/trace");
+
+export function describe(): string {
+	return "delete a build";
+}
+
+export function getCommand(args: string[]): BuildDelete {
+	return new BuildDelete(args);
+}
+
+export class BuildDelete extends buildBase.BuildBase<buildBase.BuildArguments, buildContracts.Build> {
+
+	protected description = "Delete a build.";
+
+	protected getHelpArgs(): string[] {
+		return ["project", "buildId"];
+	}
+
+	public exec(): Q.Promise<void> {
+		trace.debug("delete-build.exec");
+		var buildapi: buildClient.IQBuildApi = this.webApi.getQBuildApi();
+		return this.commandArgs.project.val().then((project) => {
+			return this.commandArgs.buildId.val().then((buildId) => {
+				return this._deleteBuild(buildapi, buildId, project);
+			});
+		});
+
+	}
+
+	public friendlyOutput(build: buildContracts.Build): void {
+		trace.println();
+	}
+
+	private _deleteBuild(buildapi: buildClient.IQBuildApi, buildId: number, project: string) {
+		trace.info("Deleting build...")
+        buildapi.deleteBuild(buildId,project)
+		return buildapi.getBuild(buildId,project).then((build: buildContracts.Build) => {
+            if (build.deleted) {
+                trace.info("build deleted")
+            } else {
+                trace.error("failed to delete")  
+            }
+        });
+	}
+}

--- a/app/exec/build/details.ts
+++ b/app/exec/build/details.ts
@@ -1,0 +1,50 @@
+import { TfCommand } from "../../lib/tfcommand";
+import args = require("../../lib/arguments");
+import buildBase = require("./default");
+import buildClient = require("vso-node-api/BuildApi");
+import buildContracts = require("vso-node-api/interfaces/BuildInterfaces");
+import trace = require("../../lib/trace");
+
+export function getCommand(args: string[]): BuildDetails {
+	return new BuildDetails(args);
+}
+
+export class BuildDetails extends buildBase.BuildBase<buildBase.BuildArguments, buildContracts.Build> {
+	protected description = "Display extended build details.";
+
+	protected getHelpArgs(): string[] {
+		return ["project", "buildId"];
+	}
+
+	public exec(): Q.Promise<buildContracts.Build> {
+		trace.debug("build-details.exec");
+		var buildapi: buildClient.IQBuildApi = this.webApi.getQBuildApi();
+		return this.commandArgs.project.val().then((project) => {
+			return this.commandArgs.buildId.val().then((buildId) => {
+				return buildapi.getBuild(buildId, project);
+			});
+		});
+
+	}
+
+	public friendlyOutput(build: buildContracts.Build): void {
+		if (!build) {
+			throw new Error("no build supplied");
+		}
+
+		trace.println();
+		trace.info("id              : %s", build.id);
+		trace.info("number (name)   : %s", build.buildNumber);
+        trace.info("definition name : %s", build.definition ? build.definition.name : "unknown");
+		trace.info("requested by    : %s", build.requestedBy ? build.requestedBy.displayName : "unknown");
+		trace.info("status          : %s", buildContracts.BuildStatus[build.status]);
+        trace.info("result          : %s", build.result ? buildContracts.BuildResult[build.result] : "unknown")
+		trace.info("queue time      : %s", build.queueTime ? build.queueTime.toJSON() : "unknown");
+        trace.info("start time      : %s", build.startTime ? build.startTime.toJSON() : "not started");
+        trace.info("finish time     : %s", build.finishTime ? build.finishTime.toJSON() : "in progress");
+        trace.info("quality         : %s", build.quality);
+        trace.info("reason          : %s", buildContracts.BuildReason[build.reason]);
+        trace.info("version         : %s", build.sourceVersion ? build.sourceVersion.replace("C","") : "unknown");
+        trace.info("API URL         : %s", build.url);       
+    }
+}

--- a/app/exec/login.ts
+++ b/app/exec/login.ts
@@ -31,7 +31,8 @@ export class Login extends TfCommand<CoreArguments, LoginResult> {
 				let agentApi = webApi.getTaskAgentApi();
 				return Q.Promise<LoginResult>((resolve, reject) => {
 					agentApi.connect((err, statusCode, obj) => {
-						if (statusCode && statusCode === 401) {
+						trace.debug("Response code: %s", statusCode.toString())
+                        if (statusCode && statusCode === 401) {
 							trace.debug("Connection failed: invalid credentials.");
 							reject("Invalid credentials.");
 						} else if (err) {


### PR DESCRIPTION
i added build details extended show - i think this might com in handy for everyone.
i added build/delete.ts (right now not working - still can figure out why) - feel free to exclude.
added debug message in login.ts to show the actual response in the login (error or message), this helped me debug the login issues i had.

BTW - 
1. Please add additional debugging info in webapi.connect() i'm having issues with logging in from machines not in our Domain (on premise server)
2. suggent how to handle custom mandatory fields in workitems when using workitem/create.ts
TODO: add build/stop.ts build/cancel.ts

