### PR TITLE
Fixed content type override bug

### DIFF
--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -472,7 +472,9 @@ export class VsixManifestBuilder extends ManifestBuilder {
 
 			let contentTypePromises: Q.Promise<any>[] = [];
 			let extTypeCounter: {[ext: string]: {[type: string]: string[]}} = {};
-			Object.keys(this.files).forEach((fileName) => {
+			Object.keys(this.files).filter((fileName) => {
+				return !this.files[fileName].contentType;
+			}).forEach((fileName) => {
 				let extension = path.extname(fileName);
 				let mimePromise;
 				if (typeMap[extension]) {


### PR DESCRIPTION
MIME type set in manifest was ignored on non-windows machines, this fixes that problem.