### PR TITLE
Update xml2js dependency to not use 0.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "validator": "^3.43.0",
     "vso-node-api": "^3.0.0",
     "winreg": "0.0.12",
-    "xml2js": "0.4.9"
+    "xml2js": "^0.4.16"
   },
   "devDependencies": {
     "del": "^1.2.0",


### PR DESCRIPTION
Update xml2js dependency to not use 0.4.9 to avoid being broken by xmllbuilder updates due the range version >=2.4.6 specification in xml2js 0.4.9

Start using caret ^0.4.16 for xml2js, which in turn uses a caret version for xmlbuilder.

Fic for #103 