### PR TITLE
Support TFS On Prem in "extension install" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ $env:TFX_TRACE=1
 ## Contributing
 
 We take contributions and fixes via Pull Request.  [Read here](docs/contributions.md) for the details.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/app/exec/extension/install.ts
+++ b/app/exec/extension/install.ts
@@ -75,7 +75,7 @@ export class ExtensionInstall extends extBase.ExtensionBase<ExtensionInstallResu
 
 	protected setCommandArgs(): void {
 		super.setCommandArgs();
-		this.registerCommandArgument("accounts", "Installation targets", "List of VSTS accounts, or list TFS Project Collections, where to install the extension.", args.ArrayArgument);
+		this.registerCommandArgument("accounts", "Installation targets", "List of VSTS accounts, or list of TFS Project Collections, where to install the extension.", args.ArrayArgument);
 	}
 
 	protected getHelpArgs(): string[] {


### PR DESCRIPTION
Support TFS On Prem in "extension install" command. For OnPrem, instead of VSTS accounts, the `--accounts` argument must be the list of project collections.
