### PR TITLE
Changes to support repository as a separate property in extension JSON

### DIFF
--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -267,6 +267,30 @@ export class VsixManifestBuilder extends ManifestBuilder {
 					});
 				}
 				break;
+			case "repository":
+				if (_.isObject(value)) {					
+					let type = null, url = null;
+					Object.keys(value).forEach((key) => {
+						if( key.toLowerCase() === "type" && value[key].toLowerCase() === "git") {
+							type = "git";
+						}
+						else if ( key.toLowerCase() === "url" ) {
+							url = value[key];
+						}
+					});
+					if( type === "git" && url !== null) {
+						this.addProperty("Microsoft.VisualStudio.Services.Links.Github", url);
+					}
+					else {
+						if( type === null) {
+							trace.warn("Either 'type' property not found for repository Or value of 'type' property is not equal to 'git'... ignoring.");
+						}
+						if( url === null) {
+							trace.warn("'url' property not found for repository... ignoring.");
+						}
+					}
+				}
+				break;
 			case "badges":
 				if (_.isArray(value)) {
 					let existingBadges = _.get<any[]>(this.data, "PackageManifest.Metadata[0].Badges[0].Badge", []);

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -269,26 +269,17 @@ export class VsixManifestBuilder extends ManifestBuilder {
 				break;
 			case "repository":
 				if (_.isObject(value)) {					
-					let type = null, url = null;
-					Object.keys(value).forEach((key) => {
-						if( key.toLowerCase() === "type" && value[key].toLowerCase() === "git") {
-							type = "git";
+						const {type, url} = value;
+						if (!type) {
+							throw new Error("Repository must have a 'type' property.");
 						}
-						else if ( key.toLowerCase() === "url" ) {
-							url = value[key];
+						if (type !== "git") {
+							throw new Error("Currently 'git' is the only supported repository type.");
 						}
-					});
-					if( type === "git" && url !== null) {
-						this.addProperty("Microsoft.VisualStudio.Services.Links.Github", url);
-					}
-					else {
-						if( type === null) {
-							trace.warn("Either 'type' property not found for repository Or value of 'type' property is not equal to 'git'... ignoring.");
+						if (!url) {
+							throw new Error("Repository must contain a 'url' property.");
 						}
-						if( url === null) {
-							trace.warn("'url' property not found for repository... ignoring.");
-						}
-					}
+						this.addProperty("Microsoft.VisualStudio.Services.Links.GitHub", url);
 				}
 				break;
 			case "badges":


### PR DESCRIPTION
This is the change to support repository property in JSON file.

Earlier we were using links property which was having "github" key along with the uri but now to maintain consistency in VSCODE and VSTS we have to planned to include another property called "repository" same like in VSCODE and after packaging the output vsixmanifest will have property referring to links to github as earlier.

Earlier JSON -
![screenshot 151](https://cloud.githubusercontent.com/assets/19949257/16563621/bc04ea82-4220-11e6-914c-f233a31f6b79.png)

Current JSON -
![screenshot 152](https://cloud.githubusercontent.com/assets/19949257/16563626/c307f9a0-4220-11e6-896c-42566cfc33d0.png)

Manifest - 
![screenshot 158](https://cloud.githubusercontent.com/assets/19949257/16586796/41d14588-42e5-11e6-8460-76e0abae6fc7.png)

