### PR TITLE
Use correct Content-Type header for css stylesheets

### DIFF
--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -41,7 +41,8 @@ export class VsixManifestBuilder extends ManifestBuilder {
 		".vsixmanifest": "text/xml",
 		".vsomanifest": "application/json",
 		".ps1": "text/ps1",
-		".js": "application/javascript"
+		".js": "application/javascript",
+		".css": "text/css"
 	};
 
 	public static manifestType = "vsix";


### PR DESCRIPTION
I've found that extension css files originating from .vsix files created using the current version of the `tfx` command line tool are served using an incorrect Content-Type header (`text/plain` instead of `text/css`) which results in them not being applied by most modern browsers.  It's quite frustrating.  

I made a change to the `CONTENT_TYPE_MAP` in `vsix-manifest-builder.ts` then re-built the tool, used it to generate and new .vsix for my extension and updated it and found that this *does allow `.css` files to be served with the correct `Content-Type` header allowing the stylesheet to be used.