### PR TITLE
Changes for adding new property for GitHub flavored rendering of mark…

### DIFF
--- a/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
+++ b/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
@@ -126,6 +126,7 @@ export class VsoManifestBuilder extends ManifestBuilder {
 			case "galleryflags":
 			case "categories":
 			case "files":
+			case "githubflavoredmarkdown":
 				break;
 			default:
 				if (key.substr(0, 2) !== "__") {

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -320,6 +320,11 @@ export class VsixManifestBuilder extends ManifestBuilder {
 					});
 				}
 				break;
+			case "githubflavoredmarkdown":
+				if(value !== "true" && value !== "false") {
+					throw "Value for gitHubFlavoredMarkdown is invalid. Valid values are true or false.";
+				}
+				this.addProperty("Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown", value);
 			case "public":
 				if (typeof value === "boolean") {
 					let flags = _.get(this.data, "PackageManifest.Metadata[0].GalleryFlags[0]", "").split(" ");

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -321,10 +321,10 @@ export class VsixManifestBuilder extends ManifestBuilder {
 				}
 				break;
 			case "githubflavoredmarkdown":
-				if(value !== "true" && value !== "false") {
-					throw "Value for gitHubFlavoredMarkdown is invalid. Valid values are true or false.";
+				if (typeof value !== "boolean") {
+					throw "Value for gitHubFlavoredMarkdown is invalid. Only boolean values are allowed.";
 				}
-				this.addProperty("Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown", value);
+				this.addProperty("Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown", value.toString());
 			case "public":
 				if (typeof value === "boolean") {
 					let flags = _.get(this.data, "PackageManifest.Metadata[0].GalleryFlags[0]", "").split(" ");


### PR DESCRIPTION
Item details markdown file in VSIX is rendered using GitHub flavored markdown, which is a bit confusing for users as it is different from GitHub's rendering of the .md file. Right now there is no way for a publisher to specify not to use GitHub flavored rendering.
Here is the issue tracking it: 
https://github.com/Microsoft/vscode-vsce/issues/76

This PR is to add a new property to vsix manifest, which will be used by marketplace to set rendering mode.