### PR TITLE
Adding support for uri for Repository and support for href and uri in badges

### DIFF
--- a/app/exec/extension/_lib/interfaces.ts
+++ b/app/exec/extension/_lib/interfaces.ts
@@ -109,7 +109,9 @@ export interface TargetDeclaration {
 
 export interface BadgeDeclaration {
 	link: string;
+	href: string;
 	imgUri: string;
+	uri: string;
 	description: string;
 }
 

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -280,17 +280,25 @@ export class VsixManifestBuilder extends ManifestBuilder {
 				break;
 			case "repository":
 				if (_.isObject(value)) {					
-						const {type, url} = value;
+						let type = value.type;
+						let url = value.url;
+						let uri = value.uri;
 						if (!type) {
 							throw new Error("Repository must have a 'type' property.");
 						}
 						if (type !== "git") {
 							throw new Error("Currently 'git' is the only supported repository type.");
 						}
-						if (!url) {
-							throw new Error("Repository must contain a 'url' property.");
+						if (!url && !uri) {
+							throw new Error("Repository must contain anyone of 'url' or 'uri' properties.");
 						}
-						this.addProperty("Microsoft.VisualStudio.Services.Links.GitHub", url);
+						if(url){
+							this.addProperty("Microsoft.VisualStudio.Services.Links.GitHub", url);							
+						}
+						else if(uri){
+							this.addProperty("Microsoft.VisualStudio.Services.Links.GitHub", uri);
+
+						}
 				}
 				break;
 			case "badges":
@@ -299,8 +307,8 @@ export class VsixManifestBuilder extends ManifestBuilder {
 					value.forEach((badge: BadgeDeclaration) => {						
 						existingBadges.push({
 							$: {
-									Link: badge.link,
-									ImgUri: badge.imgUri,
+									Link: badge.link || badge.href,
+									ImgUri: badge.imgUri || badge.uri,
 									Description: badge.description
 							}
 						});


### PR DESCRIPTION
The ask was to have 
support for uri/url for Repository and 
support for link/href and imgUri/uri for Badges

> Will Smythe from the VSTS team wanted a few changes to the extension manifest before making it live. He mentioned that few properties in the manifest support multiple keys to aid developers coding for VSTS and VS Code, and wanted that change done with respect to the repository property and the badges property in the manifest. Below is a brief summary of the changes:

>Support “uri” also (in addition to the current “url”) for the repository property
- 	This way “repository”: { “type” : “git”, “uri” : “https://github.com/mycompany/project” } will be valid

>Similarly for the badges section support “uri” as well as the key for the “imgUri” property and “href” as well for the “link” property
- 	This way both the VSTS and the VS Code implementations will be valid
