### PR TITLE
Adding support for resourceProperties to vsix manifest

### DIFF
--- a/app/exec/extension/_lib/extension-composer-factory.ts
+++ b/app/exec/extension/_lib/extension-composer-factory.ts
@@ -21,6 +21,7 @@ export class ComposerFactory {
 			switch (target.id) {
 				case "Microsoft.VisualStudio.Services" :
 				case "Microsoft.VisualStudio.Services.Cloud" :
+				case "Microsoft.VisualStudio.Services.Resource.Cloud" :
 				case "Microsoft.TeamFoundation.Server" :
 					composers.push(new VSSExtensionComposer(settings));
 					break;

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -107,6 +107,14 @@ export class Merger {
 				partials.forEach((partial) => {
 					if (_.isArray(partial["targets"])) {
 						targets = targets.concat(partial["targets"]);
+
+						if(targets.length > 0) {
+							targets.forEach((target) => {
+								if(target.id === "Microsoft.VisualStudio.Services.Resource.Cloud" && !partial["resourceProperties"]) {
+									throw new Error("\"resourceProperties\" must be present for extension having target Microsoft.VisualStudio.Services.Resource.Cloud");
+								}
+							});
+						}
 					}
 				});
 				this.extensionComposer = ComposerFactory.GetComposer(this.settings, targets);

--- a/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
+++ b/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
@@ -131,6 +131,8 @@ export class VsoManifestBuilder extends ManifestBuilder {
 			case "categories":
 			case "files":
 			case "githubflavoredmarkdown":
+			case "resourceproperties":
+			case "showpricingcalculator":
 				break;
 			default:
 				if (key.substr(0, 2) !== "__") {

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -329,6 +329,7 @@ export class VsixManifestBuilder extends ManifestBuilder {
 					throw "Value for gitHubFlavoredMarkdown is invalid. Only boolean values are allowed.";
 				}
 				this.addProperty("Microsoft.VisualStudio.Services.GitHubFlavoredMarkdown", value.toString());
+				break;
 			case "public":
 				if (typeof value === "boolean") {
 					let flags = _.get(this.data, "PackageManifest.Metadata[0].GalleryFlags[0]", "").split(" ");
@@ -364,6 +365,38 @@ export class VsixManifestBuilder extends ManifestBuilder {
 						this.addAsset(asset);
 					});
 				}
+				break;
+			case "resourceproperties":
+				if(_.isObject(value)) {
+					const {name, unitsName, targetLinkText, targetLink, quantityHelpText} = value;
+					if (name) {
+						this.addProperty("Microsoft.VisualStudio.Services.Resource.Cloud.Name", name);
+					} 
+					else {
+						throw new Error("resourceProperties must have a 'name' property.");
+					}
+					if (unitsName) {
+						this.addProperty("Microsoft.VisualStudio.Services.Resource.Cloud.UnitsName", unitsName);
+					} 
+					else {
+						throw new Error("resourceProperties must have a 'unitsName' property.");
+					}
+					if(targetLinkText) {
+						this.addProperty("Microsoft.VisualStudio.Services.Resource.Cloud.TargetLinkText", targetLinkText);
+					}
+					if(targetLink) {
+						this.addProperty("Microsoft.VisualStudio.Services.Resource.Cloud.TargetLink", targetLink);
+					}
+					if(quantityHelpText) {
+						this.addProperty("Microsoft.VisualStudio.Services.Resource.Cloud.QuantityHelpText", quantityHelpText);
+					}
+				}
+				break;
+			case "showpricingcalculator":
+				if (typeof value !== "boolean") {
+					throw "Value for showPricingCalculator is invalid. Only boolean values are allowed.";
+				}
+				this.addProperty("Microsoft.VisualStudio.Services.Content.Pricing.PriceCalculator", value.toString());
 				break;
 		}
 	}


### PR DESCRIPTION
I want to update tfx-cli tool to accommodate changes for resource type of extensions. For this, extension json file will have following properties:

  ```
"resourceProperties": {
        “name”: “<value>”,                                 //This will be mandatory
        “unitsName”: “<value>”,                        //This will be mandatory
        “targetLinkText”: “<label>”,
        “targetLink”: “<button_target>”,
        “quantityHelpText”: “<help_text>”
  },
  "showPricingCalculator": "true"
```

Above properties will be translated to vsixmanifest as follows:

```
<Property Id="Microsoft.VisualStudio.Services.Content.Pricing.PriceCalculator" Value="true" />
<Property Id="Microsoft.VisualStudio.Services.Resource.Cloud.Name" Value="<value>" />
<Property Id="Microsoft.VisualStudio.Services.Resource.Cloud.UnitsName" Value="<value>" />
<Property Id="Microsoft.VisualStudio.Services.Resource.Cloud.TargetLinkText" Value="<label>" />
<Property Id="Microsoft.VisualStudio.Services.Resource.Cloud.TargetLink" Value="<target>" />
<Property Id="Microsoft.VisualStudio.Services.Resource.Cloud.QuantityHelpText" Value="<help_text>" />
```
