### PR TITLE
fix(tsconfig): emit unix friendly entry point

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 		"moduleResolution": "node",
 		"declaration": false,
 		"sourceMap": true,
-		"newLine": "LF",
+		"newLine": "lf",
 		"lib": ["es5", "es2015", "es6"],
 		"outDir": "_build"
 	},


### PR DESCRIPTION
I'm suspecting the issues related to:

``` sh
env: node\r: No such file or directory
```

are due to a problem with tsconfig where newLine: 'LF' is uppercase (as http://json.schemastore.org/tsconfig) dictates. However, the compiler's parser seems to be doing the exact opposite (around line 49175 in current HEAD Microsoft/TypeScript@6814c1d883)

Related issue: #162 
