### PR TITLE
Fixing a broken link for publishing help

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -73,7 +73,7 @@ tfx extension publish --publisher mypublisher --manifest-globs myextension.json 
 
 1. By default, `publish` first packages the extension using the same mechanism as `tfx extension create`. All options available for `create` are available for `publish`.
 2. If an Extension with the same ID already exists publisher, the command will attempt to update the extension.
-3. When you run the `publish` command, you will be prompted for a Personal Access Token to authenticate to the Marketplace. For more information about obtaining a Personal Access Token, see [Publish from the command line](https://www.visualstudio.com/en-us/integrate/extensions/publish/command-line).
+3. When you run the `publish` command, you will be prompted for a Personal Access Token to authenticate to the Marketplace. For more information about obtaining a Personal Access Token, see [Publish from the command line](https://www.visualstudio.com/en-us/docs/integrate/extensions/publish/command-line).
 
 
 


### PR DESCRIPTION
The old link was redirecting users here: https://www.visualstudio.com/en-us/docs/integrate/extensions/overview

Instead, users should be taken to this topic: https://www.visualstudio.com/en-us/docs/integrate/extensions/publish/command-line 