### PR TITLE
Add support for showPricingCalculator to vsix manifest

### DIFF
--- a/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
+++ b/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
@@ -131,6 +131,7 @@ export class VsoManifestBuilder extends ManifestBuilder {
 			case "categories":
 			case "files":
 			case "githubflavoredmarkdown":
+			case "showpricingcalculator":
 				break;
 			default:
 				if (key.substr(0, 2) !== "__") {

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -368,6 +368,12 @@ export class VsixManifestBuilder extends ManifestBuilder {
 					});
 				}
 				break;
+			case "showpricingcalculator":
+				if (typeof value !== "boolean") {
+					throw new Error("Value for showPricingCalculator is invalid. Only boolean values are allowed.");
+				}
+				this.addProperty("Microsoft.VisualStudio.Services.Content.Pricing.PriceCalculator", value.toString());
+				break;
 		}
 	}
 


### PR DESCRIPTION
This PR updates tfx to include the showPricingCalculator property. The extension file property:

```json
"showPricingCalculator": true
````

will be translated into the vsixmanifest as:

```xml
<Property Id="Microsoft.VisualStudio.Services.Content.Pricing.PriceCalculator" Value="true"/>
```