### PR TITLE
Adding support for custom gallery properties.

### DIFF
--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -403,7 +403,7 @@ export class VsixManifestBuilder extends ManifestBuilder {
 				if (_.isArray(value)) {
 					value.forEach((propertyGroup) => {						
 						Object.keys(propertyGroup).forEach((propertyKey: string) => {
-							if (propertyKey && propertyGroup[propertyKey]) {
+							if (typeof propertyKey === "string" && propertyKey.length > 0 && propertyGroup[propertyKey]) {
 
 								// Property ID would be in upper camel case (First letter Capital)
 								let ucck: string = _.upperFirst(propertyKey);
@@ -413,14 +413,14 @@ export class VsixManifestBuilder extends ManifestBuilder {
 								let existingProperties = _.get<any[]>(this.data, "PackageManifest.Metadata[0].Properties[0].Property", []);
 								let pIds = existingProperties.map(p => _.get(p, "$.Id"));
 								if (_.intersection([propertyName], pIds).length !== 0) {
-									trace.warn("multiple entries found for same property group in vss-extension.json ... ignoring the duplicates.");
+									trace.warn("multiple entries found for the same property group in the extension manifest ... ignoring the duplicates.");
 								}
 								else {										
 									this.addProperty(propertyName, String(propertyGroup[propertyKey]));
 								}
 							}
 							else {
-								trace.warn("incorrectly formed property group in vss-extension.json ... ignoring.");
+								trace.warn("incorrectly formed property group in the extension manifest ... ignoring.");
 							}
 						})						
 					});					

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -401,29 +401,26 @@ export class VsixManifestBuilder extends ManifestBuilder {
 				 * The Gallery Properties would be a generic array of JSON elements
 				 */
 				if (_.isArray(value)) {
-					value.forEach((propertyGroup: any) => {						
+					value.forEach((propertyGroup) => {						
 						Object.keys(propertyGroup).forEach((propertyKey: string) => {
-							if(propertyKey && propertyGroup[propertyKey]) {
+							if (propertyKey && propertyGroup[propertyKey]) {
 
 								// Property ID would be in upper camel case (First letter Capital)
-								let ucck: string = propertyKey.charAt(0).toUpperCase() + propertyKey.slice(1);
-								trace.debug("Property key %s.", ucck);
-								trace.debug("Property value %s.", String(propertyGroup[propertyKey]));
-								
+								let ucck: string = _.upperFirst(propertyKey);
 								let propertyName: string = "Microsoft.VisualStudio.Services.GalleryProperties." + ucck;
 
 								// Check for duplicates								
 								let existingProperties = _.get<any[]>(this.data, "PackageManifest.Metadata[0].Properties[0].Property", []);
-								let pIds = existingProperties.map(function (p) { return _.get(p, "$.Id"); });
+								let pIds = existingProperties.map(p => _.get(p, "$.Id"));
 								if (_.intersection([propertyName], pIds).length !== 0) {
-									trace.warn("multiple entries found for same property group ... ignoring the duplicates.");
+									trace.warn("multiple entries found for same property group in vss-extension.json ... ignoring the duplicates.");
 								}
 								else {										
 									this.addProperty(propertyName, String(propertyGroup[propertyKey]));
 								}
 							}
 							else {
-								trace.warn("incorrectly formed property group ... ignoring.");
+								trace.warn("incorrectly formed property group in vss-extension.json ... ignoring.");
 							}
 						})						
 					});					

--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -396,6 +396,39 @@ export class VsixManifestBuilder extends ManifestBuilder {
 				}
 				this.addProperty("Microsoft.VisualStudio.Services.Content.Pricing.PriceCalculator", value.toString());
 				break;
+			case "galleryproperties":
+				/**
+				 * The Gallery Properties would be a generic array of JSON elements
+				 */
+				if (_.isArray(value)) {
+					value.forEach((propertyGroup: any) => {						
+						Object.keys(propertyGroup).forEach((propertyKey: string) => {
+							if(propertyKey && propertyGroup[propertyKey]) {
+
+								// Property ID would be in upper camel case (First letter Capital)
+								let ucck: string = propertyKey.charAt(0).toUpperCase() + propertyKey.slice(1);
+								trace.debug("Property key %s.", ucck);
+								trace.debug("Property value %s.", String(propertyGroup[propertyKey]));
+								
+								let propertyName: string = "Microsoft.VisualStudio.Services.GalleryProperties." + ucck;
+
+								// Check for duplicates								
+								let existingProperties = _.get<any[]>(this.data, "PackageManifest.Metadata[0].Properties[0].Property", []);
+								let pIds = existingProperties.map(function (p) { return _.get(p, "$.Id"); });
+								if (_.intersection([propertyName], pIds).length !== 0) {
+									trace.warn("multiple entries found for same property group ... ignoring the duplicates.");
+								}
+								else {										
+									this.addProperty(propertyName, String(propertyGroup[propertyKey]));
+								}
+							}
+							else {
+								trace.warn("incorrectly formed property group ... ignoring.");
+							}
+						})						
+					});					
+				}
+				break;
 		}
 	}
 


### PR DESCRIPTION
Support a generic dictionary of following kind in the JSON manifest (vss-extension.json)
"galleryProperties": [{
            "key": "value"
        }]
which tfx-cli can interpret and convert to following in the VSIX manifest
<Property Id="Microsoft.VisualStudio.Services.GalleryProperties.<Key>" Value="<Value>" />

Run sanity tests.