### PR TITLE
chore: Ignore .vscode from NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ _build/tests
 gulpfile.js
 tsconfig.json
 tmp/
+.vscode/


### PR DESCRIPTION
I thought this was done automatically for `.` folders, but noticed it in my node_modules