### PR TITLE
Remove intermediary createdExtensionVsixPath var

### DIFF
--- a/app/exec/extension/publish.ts
+++ b/app/exec/extension/publish.ts
@@ -65,18 +65,15 @@ export class ExtensionPublish extends extBase.ExtensionBase<ExtensionPublishResu
         const publishSettings = await this.getPublishSettings();
 
         let extensionCreatePromise: Promise<string>;
-        let createdExtensionVsixPath: string;
         if (publishSettings.vsixPath) {
             result.packaged = null;
-            createdExtensionVsixPath = publishSettings.vsixPath;
         } else {
             // Run two async operations in parallel and destructure the result.
             const [mergeSettings, packageSettings] = await Promise.all([this.getMergeSettings(), this.getPackageSettings()]);
             const createdExtension = await createExtension(mergeSettings, packageSettings);
             result.packaged = createdExtension.path;
-            createdExtensionVsixPath = createdExtension.path;
+            publishSettings.vsixPath = createdExtension.path;
         }
-        publishSettings.vsixPath = createdExtensionVsixPath;
         const packagePublisher = new publishUtils.PackagePublisher(publishSettings, galleryApi);
         const publishedExtension = await packagePublisher.publish();
         result.published = true;

--- a/app/exec/extension/publish.ts
+++ b/app/exec/extension/publish.ts
@@ -71,7 +71,6 @@ export class ExtensionPublish extends extBase.ExtensionBase<ExtensionPublishResu
 		const publishSettings = await this.getPublishSettings();
 
 		let extensionCreatePromise: Promise<string>;
-		let createdExtensionVsixPath: string;
 		if (publishSettings.vsixPath) {
 			result.packaged = null;
 		} else {


### PR DESCRIPTION
- One branch was setting the temp variable and then setting it back afterwards
- The other branch could just do the single set for publishSettings.vsixPath