### PR TITLE
Fix engines/node in package.json for NodeJS 8+

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "webpack": "^1.13.2"
   },
   "engines": {
-    "npm": ">=8.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Microsoft Corporation",
   "contributors": [


### PR DESCRIPTION
Fix requiring NodeJS 8 or later, as per intent of https://github.com/Microsoft/tfs-cli/commit/11745aa9a0d4790f23892a59141b40a02fa8f209 /cc @trevorsg 

Fixes https://github.com/Microsoft/tfs-cli/issues/288