### PR TITLE
Fix Task Name Validation

### DIFF
--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -65,7 +65,7 @@ export function validateTask(taskPath: string, taskData: any): string[] {
 		issues.push(vn + ": id is a required guid");
 	}
 
-	if (!taskData.name || !check.isAlphanumeric(taskData.name)) {
+	if (!taskData.name || !check.matches(taskData.name, /^[A-Za-z0-9\-]+$/)) {
 		issues.push(vn + ": name is a required alphanumeric string");
 	}
 


### PR DESCRIPTION
Fixes #297 by updating tfx's validation of the task name to use the same regex as the task manifest schema (`/^[A-Za-z0-9\-]+$/`)

* Task schema for name https://github.com/Microsoft/azure-pipelines-task-lib/blob/master/tasks.schema.json#L16
* tfx jsonvalidate is using the `isAlphanumeric` function from the validator library here: https://github.com/Microsoft/tfs-cli/blob/master/app/lib/jsonvalidate.ts#L68
* source for the `isAlphanumeric` function https://github.com/chriso/validator.js/blob/master/validator.js#L866