### PR TITLE
Fix uploading task zip to preserve original file stream

### DIFF
--- a/app/exec/build/tasks/upload.ts
+++ b/app/exec/build/tasks/upload.ts
@@ -40,11 +40,8 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 		}
 
 		if (taskZipPath) {
-			//var readStream = fs.createReadStream(taskZipPath);
-
 			// User provided an already zipped task, upload that.
 			const data: Buffer = fs.readFileSync(taskZipPath);
-			console.log(`initial file buffer size: ${data.byteLength}`);
 			const z: zip = await zip.loadAsync(data);
 
 			// find task.json inside zip, make sure its there then deserialize content
@@ -53,14 +50,7 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 
 			sourceLocation = taskZipPath;
 			taskId = taskJson.id;
-			//taskStream = z.generateNodeStream();
 			taskStream = fs.createReadStream(taskZipPath);
-
-			// console.log('writing new stream to file');
-			// const reloadedZip: string = 'D:\\reloaded.zip';
-			// fs.writeFileSync(reloadedZip, taskStream);
-			// const reloadedData = fs.readFileSync(reloadedZip);
-			// console.log(`reloaded file buffer size: ${reloadedData.byteLength}`);
 		} else {
 			// User provided the path to a directory with the task content
 			const taskPath: string = taskPaths[0];
@@ -86,9 +76,6 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 		const collectionUrl: string = this.connection.getCollectionUrl();
 		trace.info("Collection URL: " + collectionUrl);
 		const agentApi: ITaskAgentApi = await this.webApi.getTaskAgentApi(collectionUrl);
-
-		// console.log('returning early');
-		// return <agentContracts.TaskDefinition> { sourceLocation: sourceLocation, };
 
 		await agentApi.uploadTaskDefinition(null, taskStream, taskId, overwrite);
 		trace.debug("Success");

--- a/app/exec/build/tasks/upload.ts
+++ b/app/exec/build/tasks/upload.ts
@@ -40,8 +40,11 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 		}
 
 		if (taskZipPath) {
+			//var readStream = fs.createReadStream(taskZipPath);
+
 			// User provided an already zipped task, upload that.
 			const data: Buffer = fs.readFileSync(taskZipPath);
+			console.log(`initial file buffer size: ${data.byteLength}`);
 			const z: zip = await zip.loadAsync(data);
 
 			// find task.json inside zip, make sure its there then deserialize content
@@ -50,7 +53,14 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 
 			sourceLocation = taskZipPath;
 			taskId = taskJson.id;
-			taskStream = z.generateNodeStream();
+			//taskStream = z.generateNodeStream();
+			taskStream = fs.createReadStream(taskZipPath);
+
+			// console.log('writing new stream to file');
+			// const reloadedZip: string = 'D:\\reloaded.zip';
+			// fs.writeFileSync(reloadedZip, taskStream);
+			// const reloadedData = fs.readFileSync(reloadedZip);
+			// console.log(`reloaded file buffer size: ${reloadedData.byteLength}`);
 		} else {
 			// User provided the path to a directory with the task content
 			const taskPath: string = taskPaths[0];
@@ -76,6 +86,9 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 		const collectionUrl: string = this.connection.getCollectionUrl();
 		trace.info("Collection URL: " + collectionUrl);
 		const agentApi: ITaskAgentApi = await this.webApi.getTaskAgentApi(collectionUrl);
+
+		// console.log('returning early');
+		// return <agentContracts.TaskDefinition> { sourceLocation: sourceLocation, };
 
 		await agentApi.uploadTaskDefinition(null, taskStream, taskId, overwrite);
 		trace.debug("Success");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.7.11",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
There was a bug in this code when uploading a task zip. We were processing the zip to get some file contents then recreating the stream. Instead, we should preserve the original file stream so that we don't break signing.