### PR TITLE
Allow flexible manifest specification, including production vs. development differences

### DIFF
--- a/app/exec/extension/_lib/interfaces.ts
+++ b/app/exec/extension/_lib/interfaces.ts
@@ -136,6 +136,19 @@ export interface MergeSettings {
 	root: string;
 
 	/*
+	 * Manifest in the form of a standard Node.js CommonJS module with an exported function.  
+	 * The function takes an environment as a parameter and must return the manifest JSON object.  
+	 * Environment variables are specified with the env command line parameter.
+	 * If this is present then manifests, manifestGlobs, json5, override, and overridesFile are ignored.
+	 */
+	manifestJs: string;
+
+	/*
+	 * A series of environment variables that are passed to the function exported from the manifestJs module.
+	 */
+	env: string[];
+
+	/*
 	 * List of paths to manifest files
 	 */
 	manifests: string[];

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -127,11 +127,13 @@ export class Merger {
 	public async merge(): Promise<VsixComponents> {
 		trace.debug("merger.merge");
 
-		const manifestPromises: Promise<any>[] = [];
 		let overridesProvided = false;
+		const manifestPromises: Promise<any>[] = [];
 
 		if (this.settings.manifestJs) {
-			manifestPromises.push(Promise.resolve(this.loadManifestJs()));
+			const result = this.loadManifestJs();
+			result.__origin = this.settings.manifestJs; // save the origin in order to resolve relative paths later.
+			manifestPromises.push(Promise.resolve(result));
 		} else {
 			let manifestFiles = await this.gatherManifests();
 			manifestFiles.forEach(file => {

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -98,17 +98,43 @@ export class Merger {
 		}
 	}
 
+	private loadManifestJs(): any {
+		trace.debug("merger.manifestJs");
+
+		// build environment object from --env parameter
+		const env = {};
+		(this.settings.env || []).forEach(kvp => { 
+			const [key, ...value] = kvp.split('=');
+			env[key] = value.join('=');
+		});
+
+		const fullJsFile = path.resolve(this.settings.manifestJs);
+		const manifestModuleFn = require(fullJsFile);
+		if (!manifestModuleFn || typeof manifestModuleFn != "function") {
+			throw new Error(`Missing export function from manifest-js file ${fullJsFile}`)
+		}
+		const manifestData = manifestModuleFn(env);
+		if (!manifestData) {
+			throw new Error(`The export function from manifest-js file ${fullJsFile} must return the manifest object`)
+		}
+		return manifestData;
+	}	
+
 	/**
 	 * Finds all manifests and merges them into two JS Objects: vsoManifest and vsixManifest
 	 * @return Q.Promise<SplitManifest> An object containing the two manifests
 	 */
-	public merge(): Promise<VsixComponents> {
+	public async merge(): Promise<VsixComponents> {
 		trace.debug("merger.merge");
 
-		return this.gatherManifests().then(files => {
-			let overridesProvided = false;
-			const manifestPromises: Promise<any>[] = [];
-			files.forEach(file => {
+		const manifestPromises: Promise<any>[] = [];
+		let overridesProvided = false;
+
+		if (this.settings.manifestJs) {
+			manifestPromises.push(Promise.resolve(this.loadManifestJs()));
+		} else {
+			let manifestFiles = await this.gatherManifests();
+			manifestFiles.forEach(file => {
 				manifestPromises.push(
 					promisify(readFile)(file, "utf8").then(data => {
 						const jsonData = data.replace(/^\uFEFF/, "");
@@ -129,141 +155,141 @@ export class Merger {
 			if (this.settings.overrides) {
 				overridesProvided = true;
 				manifestPromises.push(Promise.resolve(this.settings.overrides));
-			}
+			}			
+		}
 
-			return Promise.all(manifestPromises).then(partials => {
-				// Determine the targets so we can construct the builders
-				let targets: TargetDeclaration[] = [];
-				partials.forEach(partial => {
-					if (_.isArray(partial["targets"])) {
-						targets = targets.concat(partial["targets"]);
-					}
-				});
-				this.extensionComposer = ComposerFactory.GetComposer(this.settings, targets);
-				this.manifestBuilders = this.extensionComposer.getBuilders();
-				let updateVersionPromise = Promise.resolve<void>(null);
-				partials.forEach((partial, partialIndex) => {
-					// Rev the version if necessary
-					if (this.settings.revVersion) {
-						if (partial["version"] && partial.__origin) {
-							try {
-								const parsedVersion = version.DynamicVersion.parse(partial["version"]);
-								const newVersion = version.DynamicVersion.increase(parsedVersion);
-								const newVersionString = newVersion.toString();
-								partial["version"] = newVersionString;
+		return Promise.all(manifestPromises).then(partials => {
+			// Determine the targets so we can construct the builders
+			let targets: TargetDeclaration[] = [];
+			partials.forEach(partial => {
+				if (_.isArray(partial["targets"])) {
+					targets = targets.concat(partial["targets"]);
+				}
+			});
+			this.extensionComposer = ComposerFactory.GetComposer(this.settings, targets);
+			this.manifestBuilders = this.extensionComposer.getBuilders();
+			let updateVersionPromise = Promise.resolve<void>(null);
+			partials.forEach((partial, partialIndex) => {
+				// Rev the version if necessary
+				if (this.settings.revVersion) {
+					if (partial["version"] && partial.__origin) {
+						try {
+							const parsedVersion = version.DynamicVersion.parse(partial["version"]);
+							const newVersion = version.DynamicVersion.increase(parsedVersion);
+							const newVersionString = newVersion.toString();
+							partial["version"] = newVersionString;
 
-								updateVersionPromise = promisify(readFile)(partial.__origin, "utf8").then(versionPartial => {
-									try {
-										let newPartial: any;
-										if (this.settings.json5) {
-											const parsed = jju.parse(versionPartial);
-											parsed["version"] = newVersionString;
-											newPartial = jju.update(versionPartial, parsed);
-										} else {
-											newPartial = jsonInPlace(versionPartial).set("version", newVersionString);
-										}
-										return promisify(writeFile)(partial.__origin, newPartial);
-									} catch (e) {
-										trace.warn(
-											"Failed to lex partial as JSON to update the version. Skipping version rev...",
-										);
+							updateVersionPromise = promisify(readFile)(partial.__origin, "utf8").then(versionPartial => {
+								try {
+									let newPartial: any;
+									if (this.settings.json5) {
+										const parsed = jju.parse(versionPartial);
+										parsed["version"] = newVersionString;
+										newPartial = jju.update(versionPartial, parsed);
+									} else {
+										newPartial = jsonInPlace(versionPartial).set("version", newVersionString);
 									}
-								});
-							} catch (e) {
-								trace.warn(
-									"Could not parse %s as a version (e.g. major.minor.patch). Skipping version rev...",
-									partial["version"],
-								);
-							}
-						}
-					}
-
-					// Transform asset paths to be relative to the root of all manifests, verify assets
-					if (_.isArray(partial["files"])) {
-						(<Array<FileDeclaration>>partial["files"]).forEach(asset => {
-							const keys = Object.keys(asset);
-							if (keys.indexOf("path") < 0) {
-								throw new Error("Files must have an absolute or relative (to the manifest) path.");
-							}
-							let absolutePath;
-							if (path.isAbsolute(asset.path)) {
-								absolutePath = asset.path;
-							} else {
-								absolutePath = path.join(path.dirname(partial.__origin), asset.path);
-							}
-							asset.path = path.relative(this.settings.root, absolutePath);
-						});
-					}
-					// Transform icon paths as above
-					if (_.isObject(partial["icons"])) {
-						const icons = partial["icons"];
-						Object.keys(icons).forEach((iconKind: string) => {
-							const absolutePath = path.join(path.dirname(partial.__origin), icons[iconKind]);
-							icons[iconKind] = path.relative(this.settings.root, absolutePath);
-						});
-					}
-
-					// Expand any directories listed in the files array
-					if (_.isArray(partial["files"])) {
-						for (let i = partial["files"].length - 1; i >= 0; --i) {
-							const fileDecl: FileDeclaration = partial["files"][i];
-							const fsPath = path.join(this.settings.root, fileDecl.path);
-							if (fs.lstatSync(fsPath).isDirectory()) {
-								Array.prototype.splice.apply(
-									partial["files"],
-									(<any[]>[i, 1]).concat(this.pathToFileDeclarations(fsPath, this.settings.root, fileDecl)),
-								);
-							}
-						}
-					}
-
-					// Process each key by each manifest builder.
-					Object.keys(partial).forEach(key => {
-						const isOverridePartial = partials.length - 1 === partialIndex && overridesProvided;
-						if (partial[key] !== undefined && (partial[key] !== null || isOverridePartial)) {
-							// Notify each manifest builder of the key/value pair
-							this.manifestBuilders.forEach(builder => {
-								builder.processKey(key, partial[key], isOverridePartial);
+									return promisify(writeFile)(partial.__origin, newPartial);
+								} catch (e) {
+									trace.warn(
+										"Failed to lex partial as JSON to update the version. Skipping version rev...",
+									);
+								}
 							});
+						} catch (e) {
+							trace.warn(
+								"Could not parse %s as a version (e.g. major.minor.patch). Skipping version rev...",
+								partial["version"],
+							);
 						}
+					}
+				}
+
+				// Transform asset paths to be relative to the root of all manifests, verify assets
+				if (_.isArray(partial["files"])) {
+					(<Array<FileDeclaration>>partial["files"]).forEach(asset => {
+						const keys = Object.keys(asset);
+						if (keys.indexOf("path") < 0) {
+							throw new Error("Files must have an absolute or relative (to the manifest) path.");
+						}
+						let absolutePath;
+						if (path.isAbsolute(asset.path)) {
+							absolutePath = asset.path;
+						} else {
+							absolutePath = path.join(path.dirname(partial.__origin), asset.path);
+						}
+						asset.path = path.relative(this.settings.root, absolutePath);
 					});
+				}
+				// Transform icon paths as above
+				if (_.isObject(partial["icons"])) {
+					const icons = partial["icons"];
+					Object.keys(icons).forEach((iconKind: string) => {
+						const absolutePath = path.join(path.dirname(partial.__origin), icons[iconKind]);
+						icons[iconKind] = path.relative(this.settings.root, absolutePath);
+					});
+				}
+
+				// Expand any directories listed in the files array
+				if (_.isArray(partial["files"])) {
+					for (let i = partial["files"].length - 1; i >= 0; --i) {
+						const fileDecl: FileDeclaration = partial["files"][i];
+						const fsPath = path.join(this.settings.root, fileDecl.path);
+						if (fs.lstatSync(fsPath).isDirectory()) {
+							Array.prototype.splice.apply(
+								partial["files"],
+								(<any[]>[i, 1]).concat(this.pathToFileDeclarations(fsPath, this.settings.root, fileDecl)),
+							);
+						}
+					}
+				}
+
+				// Process each key by each manifest builder.
+				Object.keys(partial).forEach(key => {
+					const isOverridePartial = partials.length - 1 === partialIndex && overridesProvided;
+					if (partial[key] !== undefined && (partial[key] !== null || isOverridePartial)) {
+						// Notify each manifest builder of the key/value pair
+						this.manifestBuilders.forEach(builder => {
+							builder.processKey(key, partial[key], isOverridePartial);
+						});
+					}
+				});
+			});
+
+			// Generate localization resources
+			const locPrepper = new loc.LocPrep.LocKeyGenerator(this.manifestBuilders);
+			const resources = locPrepper.generateLocalizationKeys();
+
+			// Build up resource data by reading the translations from disk
+			return this.buildResourcesData().then(resourceData => {
+				if (resourceData) {
+					resourceData["defaults"] = resources.combined;
+				}
+
+				// Build up a master file list
+				const packageFiles: PackageFiles = {};
+				this.manifestBuilders.forEach(builder => {
+					_.assign(packageFiles, builder.files);
 				});
 
-				// Generate localization resources
-				const locPrepper = new loc.LocPrep.LocKeyGenerator(this.manifestBuilders);
-				const resources = locPrepper.generateLocalizationKeys();
+				const components: VsixComponents = { builders: this.manifestBuilders, resources: resources };
 
-				// Build up resource data by reading the translations from disk
-				return this.buildResourcesData().then(resourceData => {
-					if (resourceData) {
-						resourceData["defaults"] = resources.combined;
-					}
-
-					// Build up a master file list
-					const packageFiles: PackageFiles = {};
-					this.manifestBuilders.forEach(builder => {
-						_.assign(packageFiles, builder.files);
-					});
-
-					const components: VsixComponents = { builders: this.manifestBuilders, resources: resources };
-
-					// Finalize each builder
-					return Promise.all(
-						[updateVersionPromise].concat(
-							this.manifestBuilders.map(b => b.finalize(packageFiles, resourceData, this.manifestBuilders)),
-						),
-					).then(() => {
-						// const the composer do validation
-						return this.extensionComposer.validate(components).then(validationResult => {
-							if (validationResult.length === 0 || this.settings.bypassValidation) {
-								return components;
-							} else {
-								throw new Error(
-									"There were errors with your extension. Address the following and re-run the tool.\n" +
-										validationResult,
-								);
-							}
-						});
+				// Finalize each builder
+				return Promise.all(
+					[updateVersionPromise].concat(
+						this.manifestBuilders.map(b => b.finalize(packageFiles, resourceData, this.manifestBuilders)),
+					),
+				).then(() => {
+					// const the composer do validation
+					return this.extensionComposer.validate(components).then(validationResult => {
+						if (validationResult.length === 0 || this.settings.bypassValidation) {
+							return components;
+						} else {
+							throw new Error(
+								"There were errors with your extension. Address the following and re-run the tool.\n" +
+									validationResult,
+							);
+						}
 					});
 				});
 			});

--- a/app/exec/extension/create.ts
+++ b/app/exec/extension/create.ts
@@ -47,6 +47,8 @@ export class ExtensionCreate extends extBase.ExtensionBase<CreationResult> {
 	protected getHelpArgs(): string[] {
 		return [
 			"root",
+			"manifestJs",
+			"env",
 			"manifests",
 			"manifestGlobs",
 			"json5",

--- a/app/exec/extension/default.ts
+++ b/app/exec/extension/default.ts
@@ -30,6 +30,8 @@ export interface ExtensionArguments extends CoreArguments {
 	extensionName: args.StringArgument;
 	json5: args.BooleanArgument;
 	locRoot: args.ExistingDirectoriesArgument;
+	manifestJs: args.StringArgument;
+	env: args.ArrayArgument;
 	manifestGlobs: args.ArrayArgument;
 	manifests: args.ArrayArgument;
 	metadataOnly: args.BooleanArgument;
@@ -75,6 +77,20 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 			"Publisher name",
 			"Use this as the publisher ID instead of what is specified in the manifest.",
 			args.StringArgument,
+		);
+		this.registerCommandArgument(
+			"manifestJs",
+			"Manifest JS file",
+			"A manifest in the form of a JS file with an exported function that can be called by node and will return the manifest JSON object.",
+			args.StringArgument,
+			null,
+		);
+		this.registerCommandArgument(
+			"env",
+			"Manifest JS environment",
+			"Environment variables passed to the Manifest JS function.",
+			args.ArrayArgument,
+			null,
 		);
 		this.registerCommandArgument(
 			"manifests",
@@ -170,6 +186,8 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 		return Promise.all([
 			this.commandArgs.root.val(),
 			this.commandArgs.locRoot.val(),
+			this.commandArgs.manifestJs.val(),
+			this.commandArgs.env.val(),
 			this.commandArgs.manifests.val(),
 			this.commandArgs.manifestGlobs.val(),
 			this.commandArgs.override.val(),
@@ -183,6 +201,8 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 			const [
 				root,
 				locRoot,
+				manifestJs,
+				env,
 				manifests,
 				manifestGlob,
 				override,
@@ -200,7 +220,7 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 				_.set(override, "extensionid", extensionId);
 			}
 			let overrideFileContent = Promise.resolve("");
-			if (overridesFile && overridesFile.length > 0) {
+			if (overridesFile && overridesFile.length > 0 && !manifestJs) {
 				overrideFileContent = promisify(readFile)(overridesFile[0], "utf8");
 			}
 			return overrideFileContent.then(contentStr => {
@@ -223,6 +243,8 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 				return {
 					root: root[0],
 					locRoot: locRoot && locRoot[0],
+					manifestJs: manifestJs,
+					env: env,
 					manifests: manifests,
 					manifestGlobs: manifestGlob,
 					overrides: mergedOverrides,

--- a/app/exec/extension/default.ts
+++ b/app/exec/extension/default.ts
@@ -30,7 +30,7 @@ export interface ExtensionArguments extends CoreArguments {
 	extensionName: args.StringArgument;
 	json5: args.BooleanArgument;
 	locRoot: args.ExistingDirectoriesArgument;
-	manifestJs: args.StringArgument;
+	manifestJs: args.ReadableFilePathsArgument;
 	env: args.ArrayArgument;
 	manifestGlobs: args.ArrayArgument;
 	manifests: args.ArrayArgument;

--- a/app/exec/extension/default.ts
+++ b/app/exec/extension/default.ts
@@ -82,7 +82,7 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 			"manifestJs",
 			"Manifest JS file",
 			"A manifest in the form of a JS file with an exported function that can be called by node and will return the manifest JSON object.",
-			args.StringArgument,
+			args.ReadableFilePathsArgument,
 			null,
 		);
 		this.registerCommandArgument(

--- a/app/exec/extension/init.ts
+++ b/app/exec/extension/init.ts
@@ -397,6 +397,8 @@ export class ExtensionInit extends extBase.ExtensionBase<InitResult> {
 				revVersion: false,
 				bypassValidation: includedSamples.length === 0, // need to bypass validation when there are no contributions
 				locRoot: null,
+				manifestJs: null,
+				env: null,
 				manifests: null,
 				overrides: {},
 				root: initPath,

--- a/app/exec/extension/publish.ts
+++ b/app/exec/extension/publish.ts
@@ -38,6 +38,8 @@ export class ExtensionPublish extends extBase.ExtensionBase<ExtensionPublishResu
 	protected getHelpArgs(): string[] {
 		return [
 			"root",
+			"manifestJs",
+			"env",
 			"manifests",
 			"manifestGlobs",
 			"json5",

--- a/app/exec/extension/resources/create.ts
+++ b/app/exec/extension/resources/create.ts
@@ -25,6 +25,8 @@ export class GenerateExtensionResources extends extBase.ExtensionBase<GenResourc
 	protected getHelpArgs(): string[] {
 		return [
 			"root",
+			"manifestJs",
+			"env",
 			"manifests",
 			"manifestGlobs",
 			"override",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -48,7 +48,7 @@ The version included in the packaged .VSIX and in the source manifest file is no
 
 #### Manifest JS file
 
-Eventually you will find the need to disambiguate in your manifest contents between development and production builds. Use the manifest-js option to supply a Node.JS CommonJS module and export a function. The function will be invoked with an environment property bag as a parameter, and must return the manifest JSON object.
+Eventually you will find the need to disambiguate in your manifest contents between development and production builds. Use the `--manifest-js` option to supply a Node.JS CommonJS module and export a function. The function will be invoked with an environment property bag as a parameter, and must return the manifest JSON object.
 
 Environment variables for the property bag are specified with the `--env` command line parameter.  These are space separated key-value pairs, e.g. `--env mode=production rootpath="c:\program files" size=large`.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,11 +15,8 @@ To learn more about TFX, its pre-reqs and how to install, see the [readme](../RE
 ### Arguments
 
 * `--root`: Root directory.
-* `--manifest-js`: Manifest in the form of a standard Node.js CommonJS module with an exported function.  
-	 The function takes an environment as a parameter and must return the manifest JSON object.  
-	 Environment variables are specified with the env command line parameter.
-	 If this is present then the manifests, manifest-globs, json5, override, and overrides-file arguments are ignored.
-* `--env`: Environment variables passed to the manifestJs module.  Space separated key-value pairs, e.g. `--env mode=prod size=large`
+* `--manifest-js`: Manifest in the form of a standard Node.js CommonJS module with an exported function. If present then the manifests, manifest-globs, json5, override, and overrides-file arguments are ignored.
+* `--env`: Environment variables passed to the manifestJs module.
 * `--manifests`: List of individual manifest files (space separated).
 * `--manifest-globs`: List of globs to find manifests (space separated).
 * `--override`: JSON string which is merged into the manifests, overriding any values.
@@ -50,6 +47,10 @@ tfx extension create --rev-version
 The version included in the packaged .VSIX and in the source manifest file is now `0.4.1`.
 
 #### Manifest JS file
+
+Eventually you will find the need to disambiguate in your manifest contents between development and production builds. Use the manifest-js option to supply a Node.JS CommonJS module and export a function. The function will be invoked with an environment property bag as a parameter, and must return the manifest JSON object.
+
+Environment variables for the property bag are specified with the `--env` command line parameter.  These are space separated key-value pairs, e.g. `--env mode=production rootpath="c:\program files" size=large`.
 
 An example manifest JS file might look like the following:
 


### PR DESCRIPTION
This PR adds support for webpack-like configuration of the manifest file by giving the option to provide a manifest js file instead of a manifest json file.

From the updated documentation:
"Use the `--manifest-js` option to supply a Node.JS CommonJS module and export a function. The function will be invoked with an environment property bag as a parameter, and must return the manifest JSON object.  Environment variables for the property bag are specified with the `--env` command line parameter.  These are space separated key-value pairs, e.g. `--env mode=production rootpath="c:\program files" size=large`."

This can address scenarios described by the following issues.  Fixes #92, Fixes #161, Fixes #258.

An example manifest JS file might look like the following.  It's inspired by David Hathaway's article on [Streamlining Azure DevOps extension development](https://devblogs.microsoft.com/devops/streamlining-azure-devops-extension-development/) but allows combining the development and release configs.

```
module.exports = (env) => {
	let [idPostfix, namePostfix] = (env.mode == "development") ? ["-dev", " [DEV]"] : ["", ""];
	let manifest = {
		manifestVersion: 1,
		id: `myextensionidentifier${idPostfix}`,
		name: `My Great Extension${namePostfix}`,
		...
		contributions: [
			{
				id: "mywidgetidentifier",
				properties: {
					name: `Super Widget${namePostfix}`,
					...
				},
				...
			}
		]
	}
	if (env.mode == 'development') {
		manifest.baseUri = "https://localhost:3000";
	}
	return manifest;
}
```