### PR TITLE
Fix REST API version for hard coded extension APIs

### DIFF
--- a/app/exec/extension/_lib/publish.ts
+++ b/app/exec/extension/_lib/publish.ts
@@ -285,7 +285,7 @@ export class SharingManager extends GalleryBase {
 
 			try {
 				let verData = await client.vsoClient.getVersioningData(
-					"5.1-preview.1",
+					"6.1-preview.1",
 					"gallery",
 					"a1e66d8f-f5de-4d16-8309-91a4e015ee46",
 					routeValues);
@@ -445,7 +445,7 @@ export class PackagePublisher extends GalleryBase {
 		};
 
 		const verData = await this.galleryClient.vsoClient.getVersioningData(
-			"5.1-preview.2",
+			"6.1-preview.2",
 			"gallery",
 			"e11ea35a-16fe-4b80-ab11-c4cab88a0966",
 			routeValues,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating to the latest REST API version.

The 5.1 preview 2 version is resulting in the wrong controller receiving the extension publish request. Updating to the latest 6.1 preview 2 version for Azure DevOps Server 2020.

This change was tested against 2020 and 2019, and works against both.