### PR TITLE
Fix --rev-version bug

### DIFF
--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -160,7 +160,7 @@ export class Merger {
 											parsed["version"] = newVersionString;
 											newPartial = jju.update(versionPartial, parsed);
 										} else {
-											newPartial = jsonInPlace(versionPartial).set("version", newVersionString);
+											newPartial = jsonInPlace(versionPartial).set("version", newVersionString).toString();
 										}
 										return promisify(writeFile)(partial.__origin, newPartial);
 									} catch (e) {


### PR DESCRIPTION
Addressing the --rev-version bug in #358.

The json-in-place set function returns an Inplace type object, which was causing issues. This adds a toString so that it can be properly written back to the json file.