### PR TITLE
Update vso-manifest-builder.ts

### DIFF
--- a/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
+++ b/app/exec/extension/_lib/targets/Microsoft.VisualStudio.Services/vso-manifest-builder.ts
@@ -89,16 +89,6 @@ export class VsoManifestBuilder extends ManifestBuilder {
 					this.singleValueProperty("eventCallbacks", value, key, override);
 				}
 				break;
-			case "constraints":
-				if (_.isArray(value)) {
-					if (!this.data.constraints) {
-						this.data.constraints = [];
-					}
-					this.data.constraints = this.data.constraints.concat(value);
-				} else {
-					throw new Error(`"constraints" must be an array of ContributionConstraint objects.`);
-				}
-				break;
 			case "restrictedto":
 				if (_.isArray(value)) {
 					this.singleValueProperty("restrictedTo", value, key, override, true);


### PR DESCRIPTION
Removed "constraints" entry, as it confuses customers, since constraints are an internal-only mechanism for filtering contributions. There's no public use for them in extensions per Ed Glas.


Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/812