### PR TITLE
Fix extension init command for non Windows users

### DIFF
--- a/app/exec/extension/init.ts
+++ b/app/exec/extension/init.ts
@@ -239,7 +239,7 @@ export class ExtensionInit extends extBase.ExtensionBase<InitResult> {
 										trace.debug("Writing buffer for " + fileName);
 										const noLeadingFolderFileName = fileName.substr(fileName.indexOf("/"));
 										const fullPath = path.join(initPath, noLeadingFolderFileName);
-										if (fullPath.endsWith("\\")) {
+										if (fullPath.endsWith("\\") || fullPath.endsWith("/")) {
 											// don't need to "write" the folders since they are handled by createFolderIfNotExists().
 											return;
 										}


### PR DESCRIPTION
This PR implements the fix suggested in [issue 363](https://github.com/microsoft/tfs-cli/issues/363).

Currently `tfx extension init` is broken for anyone on a non Windows system. 
The code in this PR now checks for both `\` and `/` when checking a file path, instead of just checking what Windows uses, `\`.