### PR TITLE
Fix cmd line parsing bug for the --manifest-js parameter

### DIFF
--- a/app/exec/extension/default.ts
+++ b/app/exec/extension/default.ts
@@ -186,7 +186,7 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 		return Promise.all([
 			this.commandArgs.root.val(),
 			this.commandArgs.locRoot.val(),
-			this.commandArgs.manifestJs.val(),
+			this.commandArgs.manifestJs.val().then(files => files && files.length ? files[0] : null),
 			this.commandArgs.env.val(),
 			this.commandArgs.manifests.val(),
 			this.commandArgs.manifestGlobs.val(),


### PR DESCRIPTION
[This change](https://github.com/microsoft/tfs-cli/pull/342#discussion_r603296197) of manifestJs from args.StringArgument to args.ReadableFilePathsArgument created a bug that causes the parser to fail when --manifest-js was specified.