### PR TITLE
Restore the use of --override and --overrides-file when --manifest-js is specified

### DIFF
--- a/app/exec/extension/_lib/interfaces.ts
+++ b/app/exec/extension/_lib/interfaces.ts
@@ -139,7 +139,7 @@ export interface MergeSettings {
 	 * Manifest in the form of a standard Node.js CommonJS module with an exported function.  
 	 * The function takes an environment as a parameter and must return the manifest JSON object.  
 	 * Environment variables are specified with the env command line parameter.
-	 * If this is present then manifests, manifestGlobs, json5, override, and overridesFile are ignored.
+	 * If this is present then manifests and manifestGlobs are ignored.
 	 */
 	manifestJs: string;
 

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -152,12 +152,12 @@ export class Merger {
 					}),
 				);
 			});
+		}
 
-			// Add the overrides if necessary
-			if (this.settings.overrides) {
-				overridesProvided = true;
-				manifestPromises.push(Promise.resolve(this.settings.overrides));
-			}			
+		// Add the overrides if necessary
+		if (this.settings.overrides) {
+			overridesProvided = true;
+			manifestPromises.push(Promise.resolve(this.settings.overrides));
 		}
 
 		return Promise.all(manifestPromises).then(partials => {

--- a/app/exec/extension/default.ts
+++ b/app/exec/extension/default.ts
@@ -220,7 +220,7 @@ export class ExtensionBase<T> extends TfCommand<ExtensionArguments, T> {
 				_.set(override, "extensionid", extensionId);
 			}
 			let overrideFileContent = Promise.resolve("");
-			if (overridesFile && overridesFile.length > 0 && !manifestJs) {
+			if (overridesFile && overridesFile.length > 0) {
 				overrideFileContent = promisify(readFile)(overridesFile[0], "utf8");
 			}
 			return overrideFileContent.then(contentStr => {

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,7 +15,7 @@ To learn more about TFX, its pre-reqs and how to install, see the [readme](../RE
 ### Arguments
 
 * `--root`: Root directory.
-* `--manifest-js`: Manifest in the form of a standard Node.js CommonJS module with an exported function. If present then the manifests, manifest-globs, json5, override, and overrides-file arguments are ignored.
+* `--manifest-js`: Manifest in the form of a standard Node.js CommonJS module with an exported function. If present then the manifests and manifest-globs arguments are ignored.
 * `--env`: Environment variables passed to the manifestJs module.
 * `--manifests`: List of individual manifest files (space separated).
 * `--manifest-globs`: List of globs to find manifests (space separated).


### PR DESCRIPTION
There are valid scenarios where you may want to use both --manifest-js and --override or --overrides-file.  For example, in ADO pipeline publishing to update the extension version with the build version from the pipeline.

In fact, the internal implementation of --publisher and --extension-id also depend on this override functionality.  This PR will allow them to be used with --manifest-js.

This PR is in response to a comment from PR #342 by @dwilsonactual.