### PR TITLE
Resolve vulnerabilities

### DIFF
--- a/app/exec/extension/_lib/loc.ts
+++ b/app/exec/extension/_lib/loc.ts
@@ -69,15 +69,7 @@ export namespace LocPrep {
 				}
 			})
 			.then(determinedPath => {
-				return new Promise((resolve, reject) => {
-					mkdirp(path.dirname(determinedPath), (err, made) => {
-						if (err) {
-							reject(err);
-						} else {
-							resolve(made);
-						}
-					});
-				}).then(() => {
+				return mkdirp(path.dirname(determinedPath)).then(() => {
 					return promisify(writeFile)(determinedPath, JSON.stringify(resources, null, 4), "utf8");
 				});
 			});

--- a/app/exec/extension/_lib/vsix-writer.ts
+++ b/app/exec/extension/_lib/vsix-writer.ts
@@ -128,7 +128,7 @@ export class VsixWriter {
 				throw new Error("--output-path must be a directory when using --metadata-only.");
 			}
 			if (!pathExists) {
-				await promisify(mkdirp)(outputPath, undefined);
+				await mkdirp(outputPath);
 			}
 
 			for (const builder of this.manifestBuilders) {
@@ -138,7 +138,7 @@ export class VsixWriter {
 						const content = fileObj.content || (await promisify(readFile)(fileObj.path, "utf-8"));
 						const writePath = path.join(this.settings.outputPath, fileObj.partName);
 						const folder = path.dirname(writePath);
-						await promisify(mkdirp)(folder, undefined);
+						await mkdirp(folder);
 						await promisify(writeFile)(writePath, content, "utf-8");
 					}
 				}
@@ -245,15 +245,7 @@ export class VsixWriter {
 		return Promise.all(builderPromises).then(() => {
 			trace.debug("Writing vsix to: %s", outputPath);
 
-			return new Promise((resolve, reject) => {
-				mkdirp(path.dirname(outputPath), (err, made) => {
-					if (err) {
-						reject(err);
-					} else {
-						resolve(made);
-					}
-				});
-			}).then(async () => {
+			return mkdirp(path.dirname(outputPath)).then(async () => {
 				let buffer = await vsix.generateAsync({
 					type: "nodebuffer",
 					compression: "DEFLATE",

--- a/app/exec/extension/init.ts
+++ b/app/exec/extension/init.ts
@@ -465,15 +465,7 @@ export class ExtensionInit extends extBase.ExtensionBase<InitResult> {
 
 	private async createFolderIfNotExists(folderPath: string) {
 		try {
-			await new Promise((resolve, reject) => {
-				mkdirp(folderPath, err => {
-					if (err) {
-						reject(err);
-					} else {
-						resolve();
-					}
-				});
-			});
+			await mkdirp(folderPath);
 		} catch {
 			// folder already exists, perhaps. Or maybe we can't write to it.
 		}

--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -1,7 +1,6 @@
 import { defer } from "./promiseUtils";
 
 var fs = require("fs");
-var shell = require("shelljs");
 var check = require("validator");
 var trace = require("./trace");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -571,6 +571,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -934,19 +939,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mute-stream": {
       "version": "0.0.4",
@@ -1037,6 +1032,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -1096,10 +1096,38 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "requires": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "dependencies": {
+        "is-core-module": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+          "requires": {
+            "has": "^1.0.3"
+          }
+        }
+      }
     },
     "revalidator": {
       "version": "0.1.8",
@@ -1144,9 +1172,14 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
-      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -1216,6 +1249,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "tar-stream": {
       "version": "1.6.1",
@@ -1326,9 +1364,9 @@
       }
     },
     "validator": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
-      "integrity": "sha1-lkZLmS1BloM9l6GUv0Cxn/VLrgU="
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "walkdir": {
       "version": "0.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,11 +103,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/shelljs": {
-      "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.3.33.tgz",
-      "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.11.tgz",
+      "integrity": "sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==",
       "dev": true,
       "requires": {
+        "@types/glob": "*",
         "@types/node": "*"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,10 +83,13 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/mkdirp": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
-      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
+      "integrity": "sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/lodash": "~4.14.110",
     "@types/mkdirp": "^1.0.2",
     "@types/node": "~8.5.1",
-    "@types/shelljs": "^0.3.30",
+    "@types/shelljs": "^0.8.11",
     "@types/uuid": "^2.0.29",
     "@types/validator": "^4.5.27",
     "@types/winreg": "^1.2.29",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/jju": "^1.4.1",
     "@types/jszip": "~3.1.2",
     "@types/lodash": "~4.14.110",
-    "@types/mkdirp": "^0.3.28",
+    "@types/mkdirp": "^1.0.2",
     "@types/node": "~8.5.1",
     "@types/shelljs": "^0.3.30",
     "@types/uuid": "^2.0.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",
@@ -30,17 +30,17 @@
     "jszip": "^3.7.1",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "onecolor": "^2.5.0",
     "os-homedir": "^1.0.1",
     "prompt": "^1.2.0",
     "read": "^1.0.6",
-    "shelljs": "^0.5.1",
+    "shelljs": "^0.8.5",
     "tmp": "0.0.26",
     "tracer": "0.7.4",
     "util.promisify": "^1.0.0",
     "uuid": "^3.0.1",
-    "validator": "^3.43.0",
+    "validator": "^13.7.0",
     "winreg": "0.0.12",
     "xml2js": "^0.4.16"
   },


### PR DESCRIPTION
Updated dependencies:
- `mkdirp` to 1.0.4 - after this update `mkdirp` function changed: now it uses a promise instead of a callback. Had to make some code changes to fix that.
- `shelljs` to 0.8.5
- `validator` to 13.7.0


List of commands tested locally:
- login
- workitem create
- workitem query
- workitem update
- workitem show
- build list
- build queue
- build show
- build tasks create
- build tasks upload
- build tasks list
- build tasks delete
- extension create