### PR TITLE
Upgrade task.json to the new version

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,21 @@
 {
 	// See https://go.microsoft.com/fwlink/?LinkId=733558
 	// for the documentation about the tasks.json format
-	"version": "0.1.0",
+	"version": "2.0.0",
 	"command": "npm",
-	"isShellCommand": true,
-	"showOutput": "always",
-	"suppressTaskName": true,
 	"tasks": [
 		{
-			"taskName": "build",
-			"args": ["run", "build"]
+			"label": "build",
+			"type": "shell",
+			"args": [
+				"run",
+				"build"
+			],
+			"problemMatcher": [],
+			"group": {
+				"_id": "build",
+				"isDefault": false
+			}
 		}
 	]
 }


### PR DESCRIPTION
**Description**: VSCode task ver 0.1.0 is deprecated at the moment.

Auto-upgraded task to ver. 2.0.0