### PR TITLE
Fix magic mime when `file` output is multiline

### DIFF
--- a/app/exec/extension/_lib/vsix-manifest-builder.ts
+++ b/app/exec/extension/_lib/vsix-manifest-builder.ts
@@ -728,7 +728,8 @@ export class VsixManifestBuilder extends ManifestBuilder {
 									}
 								} else {
 									if (typeof stdout === "string") {
-										let magicMime = _.trimEnd(stdout.substr(stdout.lastIndexOf(" ") + 1), "\n");
+										const firstLine = stdout.split("\n")[0]
+										const magicMime = firstLine.substring(firstLine.lastIndexOf(" ") + 1);
 										trace.debug("Magic mime type for %s is %s.", fileName, magicMime);
 										if (magicMime) {
 											if (extension) {


### PR DESCRIPTION
Closes #414 

There is no need to use `_.trimEnd()` anymore, since `split()` already handles this.

`.substr()` is deprecated and `.substring()` is supported (at least) in Node v10.21.0, which commonly is the lowest Node version used when developing Azure DevOps extensions.

This outputs `application/x-mach-binary` for the following `file` output:

```
datadog-ci/node_modules/fsevents/fsevents.node: application/x-mach-binary
datadog-ci/node_modules/fsevents/fsevents.node (for architecture x86_64):       application/x-mach-binary
datadog-ci/node_modules/fsevents/fsevents.node (for architecture arm64):        application/x-mach-binary
```