### PR TITLE
Added new parameter skipCertValidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ To avoid providing credentials with every command, you can login once. Currently
 
 > Warning! Using this feature will store your login credentials on disk in plain text.
 
+> To skip certificate validation connecting to On-Prem Azure DevOps Server you can use parameter `skipCertValidation`
+
 #### Personal access token
 
 Start by [creating a personal access token](http://roadtoalm.com/2015/07/22/using-personal-access-tokens-to-access-visual-studio-online) and paste it into the login command.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To avoid providing credentials with every command, you can login once. Currently
 
 > Warning! Using this feature will store your login credentials on disk in plain text.
 
-> To skip certificate validation connecting to On-Prem Azure DevOps Server you can use parameter `skipCertValidation`
+> To skip certificate validation connecting to On-Prem Azure DevOps Server you can use parameter `--skip-cert-validation`
 
 #### Personal access token
 

--- a/app/exec/login.ts
+++ b/app/exec/login.ts
@@ -24,10 +24,12 @@ export class Login extends TfCommand<CoreArguments, LoginResult> {
 	public async exec(): Promise<LoginResult> {
 		trace.debug("Login.exec");
 		return this.commandArgs.serviceUrl.val().then(async collectionUrl => {
-			global['_vsts_task_lib_skip_cert_validation'] = await this.commandArgs.skipCertValidation.val(false);
+			const skipCertValidation = await this.commandArgs.skipCertValidation.val(false);
 
 			const authHandler = await this.getCredentials(collectionUrl, false);
-			const webApi = await this.getWebApi();
+			const webApi = await this.getWebApi({
+				ignoreSslError: skipCertValidation
+			});
 			const locationsApi = await webApi.getLocationsApi();
 
 			try {

--- a/app/exec/login.ts
+++ b/app/exec/login.ts
@@ -24,6 +24,8 @@ export class Login extends TfCommand<CoreArguments, LoginResult> {
 	public async exec(): Promise<LoginResult> {
 		trace.debug("Login.exec");
 		return this.commandArgs.serviceUrl.val().then(async collectionUrl => {
+			global['_vsts_task_lib_skip_cert_validation'] = await this.commandArgs.skipCertValidation.val(false);
+
 			const authHandler = await this.getCredentials(collectionUrl, false);
 			const webApi = await this.getWebApi();
 			const locationsApi = await webApi.getLocationsApi();

--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -37,6 +37,7 @@ export interface CoreArguments {
 	noPrompt: args.BooleanArgument;
 	noColor: args.BooleanArgument;
 	debugLogStream: args.StringArgument;
+	skipCertValidation: args.BooleanArgument;
 }
 
 export interface Executor<TResult> {
@@ -334,6 +335,13 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 			args.StringArgument,
 			"stdout",
 		);
+		this.registerCommandArgument(
+			"skipCertValidation",
+			"Skip Certificate Validation",
+			"Skip certificate validation during login",
+			args.BooleanArgument,
+			"false",
+		);
 	}
 
 	/**
@@ -549,7 +557,7 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 
 					if (this.serverCommand) {
 						result += eol + cyan("Global server command arguments:") + eol;
-						["authType", "username", "password", "token", "serviceUrl", "fiddler", "proxy"].forEach(arg => {
+						["authType", "username", "password", "token", "serviceUrl", "fiddler", "proxy", "skipCertValidation"].forEach(arg => {
 							result += singleArgData(arg, 11);
 						});
 					}

--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -18,6 +18,7 @@ import fsUtils = require("./fsUtils");
 import { promisify } from "util";
 import trace = require("./trace");
 import version = require("./version");
+import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBaseInterfaces";
 
 export interface CoreArguments {
 	[key: string]: args.Argument<any>;
@@ -417,11 +418,11 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 		});
 	}
 
-	public getWebApi(): Promise<WebApi> {
+	public getWebApi(options?: IRequestOptions): Promise<WebApi> {
 		return this.commandArgs.serviceUrl.val().then(url => {
 			return this.getCredentials(url).then(handler => {
 				this.connection = new TfsConnection(url);
-				this.webApi = new WebApi(url, handler);
+				this.webApi = new WebApi(url, handler, options);
 				return this.webApi;
 			});
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description**: added new parameter `--skipCertValidation` (`--skip-cert-validation`) to group `Global server command argument` which allows to skip certificate validation during login

**Related issue:** https://github.com/microsoft/tfs-cli/issues/419

```bash
~ tfx login
TFS Cross Platform Command Line Interface v0.13.0
Copyright Microsoft Corporation
> Service URL: https://some-url
> Personal access token:
error: Error: Connection failed. Check your internet connection & collection URL.
error: Message: unable to get local issuer certificate

~ tfx login --skip-cert-validation
TFS Cross Platform Command Line Interface v0.13.0
Copyright Microsoft Corporation
> Service URL: https://some-url
> Personal access token:                                           
Logged in successfully
```