### PR TITLE
Added deprecated runner validation

### DIFF
--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -4,6 +4,8 @@ var fs = require("fs");
 var check = require("validator");
 var trace = require("./trace");
 
+const deprecatedRunners = ["Node6"];
+
 /*
  * Checks a json file for correct formatting against some validation function
  * @param jsonFilePath path to the json file being validated
@@ -36,6 +38,7 @@ export function validate(jsonFilePath: string, jsonMissingErrorMessage?: string)
 	}
 
 	trace.debug("Json is valid.");
+	validateRunner(taskJson);
 	deferred.resolve(taskJson);
 	return <any>deferred.promise;
 }
@@ -47,6 +50,20 @@ export function exists(path: string, errorMessage: string) {
 	if (!fs.existsSync(path)) {
 		trace.debug(errorMessage);
 		throw new Error(errorMessage);
+	}
+}
+
+/*
+ * Validates a task against deprecated runner
+ * @param taskData the parsed json file
+ */
+export function validateRunner(taskData: any) {
+	if(taskData == undefined || taskData.execution == undefined)
+		return
+
+	const validRunnerCount = Object.keys(taskData.execution).filter(itm=> deprecatedRunners.indexOf(itm) == -1) || 0;
+	if(validRunnerCount == 0){
+		trace.warn("Task %s is dependent on a task runner that is end-of-life and will be removed in the future. Authors should review Node upgrade guidance: https://aka.ms/node-runner-guidance.",taskData.name)
 	}
 }
 


### PR DESCRIPTION
**Description**: Some node runners go to EOL. We need to notify authors if there are only deprecated runners. 
**How it works**: While uploading task to Azure Devops, validation checks the execution handlers in task.json file. If there is not any runner rather than deprecated ones, warning will appear. 
Warning looks like:

<img width="533" alt="image" src="https://user-images.githubusercontent.com/110806089/219348195-adb8e144-0f40-4cd5-824d-5bc261d3a297.png">
