### PR TITLE
Implement caching value of skipCertValidation 

### DIFF
--- a/app/exec/login.ts
+++ b/app/exec/login.ts
@@ -44,6 +44,7 @@ export class Login extends TfCommand<CoreArguments, LoginResult> {
 				}
 				await tfxCredStore.storeCredential(collectionUrl, "allusers", credString);
 				await tfxCache.setItem("cache", "connection", collectionUrl);
+				await tfxCache.setItem("cache", "skipCertValidation", skipCertValidation.toString());
 				return { success: true } as LoginResult;
 			} catch (err) {
 				if (err && err.statusCode && err.statusCode === 401) {

--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -418,7 +418,13 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 		});
 	}
 
-	public getWebApi(options?: IRequestOptions): Promise<WebApi> {
+	public async getWebApi(options?: IRequestOptions): Promise<WebApi> {
+		// try to get value of skipCertValidation from cache
+		let tfxCache = new DiskCache("tfx");
+		if (await tfxCache.itemExists("cache", "skipCertValidation")) {
+			const skipCertValidation = await tfxCache.getItem("cache", "skipCertValidation");
+			options = {...options, ignoreSslError: <any>skipCertValidation}
+		}
 		return this.commandArgs.serviceUrl.val().then(url => {
 			return this.getCredentials(url).then(handler => {
 				this.connection = new TfsConnection(url);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description of issue

Implemented parameter `skipCertValidation` via PR https://github.com/microsoft/tfs-cli/pull/421 only took affected on login command and further commands missed the value to be able to skip certificate validation

### Description of fix

Implemented logic to save value of `skipCertValidation` to cache and read the value from `cache` when `webApi` is initialized