### PR TITLE
Bump tfs-cli tool version to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Description**:
Since `0.15.0` was already published to npmjs registry, this PR bumps package version to 0.16.0