### PR TITLE
CodeQL 3000 fix

### DIFF
--- a/.azure-pipelines/azure-pipeline.yml
+++ b/.azure-pipelines/azure-pipeline.yml
@@ -79,3 +79,9 @@ extends:
               npm pack
               cp *.tgz '$(Build.ArtifactStagingDirectory)'
             displayName: Run npm-pack and copy to ArtifactStagingDirectory
+        
+        # Install node 16 for CodeQL 3000
+        - task: NodeTool@0
+          displayName: Use node 10
+          inputs:
+            versionSpec: "16.x"

--- a/.azure-pipelines/azure-pipeline.yml
+++ b/.azure-pipelines/azure-pipeline.yml
@@ -82,6 +82,6 @@ extends:
         
         # Install node 16 for CodeQL 3000
         - task: NodeTool@0
-          displayName: Use node 10
+          displayName: Use node 16
           inputs:
             versionSpec: "16.x"


### PR DESCRIPTION
fixes [CodeQL error ](https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=26850245&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=4bb9ee66-d15b-54bf-dea1-47f4e6298783&l=62)

**Description**
- Added node16 installation for CodeQL 3000, because the task requires node 14+ and the default node version after pipeline run sets to 10.x

**Testing**