### PR TITLE
Update the list of deprecated runners

### DIFF
--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -4,7 +4,7 @@ var fs = require("fs");
 var check = require("validator");
 var trace = require("./trace");
 
-const deprecatedRunners = ["Node6"];
+const deprecatedRunners = ["Node6", "Node10", "Node16"];
 
 /*
  * Checks a json file for correct formatting against some validation function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**WI**: [AB#2122131](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2122131)

**Description**

Added `Node10` and `Node16` to the list of deprecated runners, as their respective Node versions reached the EoL.

**Tests**

When there is at least one runner in `task.json` that is not deprecated (i.e. Node20_1), no warning is displayed on task upload:

![successful_upload](https://github.com/microsoft/tfs-cli/assets/107044793/e2797234-d9a1-4b89-a23c-8d88caebb0b7)

When all runners in  `task.json` are deprecated, this warning is displayed:

 
![warning](https://github.com/microsoft/tfs-cli/assets/107044793/2decc041-b71b-40c1-8af5-38bbf03737ad)
