### PR TITLE
[Bug Fix] on-prem TFS missing collections

### DIFF
--- a/app/lib/connection.ts
+++ b/app/lib/connection.ts
@@ -26,8 +26,8 @@ export class TfsConnection {
 			throw new Error(
 				"Invalid service url - path is too long. A service URL should include the account/application URL and the collection, e.g. https://fabrikam.visualstudio.com/DefaultCollection or http://tfs-server:8080/tfs/DefaultCollection",
 			);
-		} else if (splitPath.length === 0) {
-			throw new Error("Expected URL path.");
+		} else if (splitPath.length === 0 || (splitPath[0] === "tfs" && splitPath.length === 1)) {
+			throw new Error("Expected URL path (collection name missing).");
 		}
 
 		if (splitPath[0].trim() !== "" || (splitPath[0] === "tfs" && splitPath[1].trim() !== "")) {


### PR DESCRIPTION
The **TfsConnection** constructor allows for invalid **serviceUrl** when using on-prem server. Subsequent commands will report success, even though they fail to do anything.

**Testing setup:**
On-prem server with a serviceUrl in the following format: `http://www.example.com/tfs`
PAT token created at the server level ex: `http://www.example.com/tfs/_usersSettings/tokens`

`tfx login`
`Service URL: {http://www.example.com/tfs}`

_it should fail here, because there is no collection path, but it does not_ 

enter `PAT token` and run a command. for example, this one will incorrectly report success.
`tfx build tasks upload --task-zip-path {path to task}`

With this PR, login will correctly fail if no collection path is provided when using on-prem.a