### PR TITLE
fixing json5 parsing issue

### DIFF
--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -103,7 +103,7 @@ export class Merger {
 
 		// build environment object from --env parameter
 		const env = {};
-		(this.settings.env || []).forEach(kvp => { 
+		(this.settings.env || []).forEach(kvp => {
 			const [key, ...value] = kvp.split('=');
 			env[key] = value.join('=');
 		});
@@ -118,7 +118,7 @@ export class Merger {
 			throw new Error(`The export function from manifest-js file ${fullJsFile} must return the manifest object`)
 		}
 		return manifestData;
-	}	
+	}
 
 	/**
 	 * Finds all manifests and merges them into two JS Objects: vsoManifest and vsixManifest
@@ -141,7 +141,7 @@ export class Merger {
 					promisify(readFile)(file, "utf8").then(data => {
 						const jsonData = data.replace(/^\uFEFF/, "");
 						try {
-							const result = this.settings.json5 ? jju.parse(jsonData) : JSON.parse(jsonData);
+							const result = jju.parse(jsonData);
 							result.__origin = file; // save the origin in order to resolve relative paths later.
 							return result;
 						} catch (err) {
@@ -189,7 +189,7 @@ export class Merger {
 										parsed["version"] = newVersionString;
 										newPartial = jju.update(versionPartial, parsed);
 									} else {
-											newPartial = jsonInPlace(versionPartial).set("version", newVersionString).toString();
+										newPartial = jsonInPlace(versionPartial).set("version", newVersionString).toString();
 									}
 									return promisify(writeFile)(partial.__origin, newPartial);
 								} catch (e) {
@@ -289,7 +289,7 @@ export class Merger {
 						} else {
 							throw new Error(
 								"There were errors with your extension. Address the following and re-run the tool.\n" +
-									validationResult,
+								validationResult,
 							);
 						}
 					});


### PR DESCRIPTION
Fixes #466 

When parsing manifest `json` files, no need to check if they're `json5` (supports comments, unquoted keys, etc.)

`jju.parse()` method already support `json` and `json5` formats.

test.json

```json
{
  name: "test",
  version: "1.0.0",
  "publisher": "test",
  categories: ["test"],
  contributions: [
    {
      "id": "home",
      "type": "ms.vss-web.hub",
    }
  ],
  // A comment
}
```

test command

```bash
node ./_build/tfx-cli.js extension create --manifests ./_build/test.json --trace-level debug
```