### PR TITLE
fixing error log format

### DIFF
--- a/app/lib/trace.ts
+++ b/app/lib/trace.ts
@@ -18,7 +18,7 @@ export function println() {
 }
 
 export function error(msg: any, ...replacements: printable[]): void {
-	log("error: ", msg, colors.bgRed, replacements, console.error);
+	log("error: ", msg, colors.bgRed.white, replacements, console.error);
 }
 
 export function success(msg: any, ...replacements: printable[]): void {


### PR DESCRIPTION
Fixes #465 

Ensuring the error log background and foreground colors are not the same to improve readability.