### PR TITLE
Implemented `task.json` validation for `tfx extension create` command

### DIFF
--- a/app/exec/build/tasks/upload.ts
+++ b/app/exec/build/tasks/upload.ts
@@ -14,10 +14,6 @@ export function getCommand(args: string[]): BuildTaskUpload {
 
 var c_taskJsonFile: string = "task.json";
 
-interface TaskJson {
-	id: string;
-}
-
 export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.TaskDefinition> {
 	protected description = "Upload a Build Task.";
 	protected serverCommand = true;
@@ -46,7 +42,7 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 
 			// find task.json inside zip, make sure its there then deserialize content
 			const fileContent: string = await z.files[c_taskJsonFile].async('text');
-			const taskJson: TaskJson = JSON.parse(fileContent);
+			const taskJson: vm.TaskJson = JSON.parse(fileContent);
 
 			sourceLocation = taskZipPath;
 			taskId = taskJson.id;
@@ -57,7 +53,7 @@ export class BuildTaskUpload extends tasksBase.BuildTaskBase<agentContracts.Task
 			vm.exists(taskPath, "specified directory " + taskPath + " does not exist.");
 
 			const taskJsonPath: string = path.join(taskPath, c_taskJsonFile);
-			const taskJson: TaskJson = await vm.validate(taskJsonPath, "no " + c_taskJsonFile + " in specified directory");
+			const taskJson: vm.TaskJson = vm.validate(taskJsonPath, "no " + c_taskJsonFile + " in specified directory");
 
 			const archive = archiver("zip");
 			archive.on("error", function(error) {

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -409,9 +409,6 @@ export class Merger {
 	}
 
 	private async validateTaskJson(taskJsonSearchPattern: string): Promise<TaskJson> {
-		let taskJsonExists = false;
-		let taskJsonPath: string;
-
 		try {
 			const matches: string[] = await promisify(glob)(taskJsonSearchPattern);
 			
@@ -420,8 +417,8 @@ export class Merger {
 				return;
 			}
 
-			taskJsonPath = matches[0];
-			taskJsonExists = await exists(taskJsonPath);
+			const taskJsonPath = matches[0];
+			const taskJsonExists = await exists(taskJsonPath);
 			
 			if (taskJsonExists) {
 				return validate(taskJsonPath, "no task.json in specified directory");
@@ -431,7 +428,7 @@ export class Merger {
 			const warningMessage = "Please, make sure the task.json file is correct. In the future, this warning will be treated as an error.\n";
 			trace.warn(err && err instanceof Error
 				? warningMessage + err.message
-				: "Error occurred while validating task.json");
+				: `Error occurred while validating task.json. ${warningMessage}`);
 		}
 	}
 }

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -427,7 +427,7 @@ export class Merger {
 			trace.error(err);
 		}
 		
-		if (taskJsonExists){
+		if (taskJsonExists) {
 			return validate(taskJsonPath, "no task.json in specified directory");
 		}
 	}

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -24,7 +24,7 @@ import version = require("../../../lib/dynamicVersion");
 import { promisify } from "util";
 import { readdir, readFile, writeFile, lstat } from "fs";
 import { exists } from "../../../lib/fsUtils";
-import { validate } from "../../../lib/jsonvalidate";
+import { validate, TaskJson } from "../../../lib/jsonvalidate";
 
 /**
  * Combines the vsix and vso manifests into one object
@@ -408,7 +408,7 @@ export class Merger {
 		return files;
 	}
 
-	private async validateTaskJson(taskJsonSearchPattern: string): Promise<any> {
+	private async validateTaskJson(taskJsonSearchPattern: string): Promise<TaskJson> {
 		let taskJsonExists = false;
 		let taskJsonPath: string;
 
@@ -423,12 +423,12 @@ export class Merger {
 			taskJsonPath = matches[0];
 			taskJsonExists = await exists(taskJsonPath);
 			
+			if (taskJsonExists) {
+				return validate(taskJsonPath, "no task.json in specified directory");
+			}
+
 		} catch (err) {
-			trace.error(err);
-		}
-		
-		if (taskJsonExists) {
-			return validate(taskJsonPath, "no task.json in specified directory");
+			trace.warn(err && err instanceof Error ? err.message : "Error occurred while validating task.json");
 		}
 	}
 }

--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -428,7 +428,10 @@ export class Merger {
 			}
 
 		} catch (err) {
-			trace.warn(err && err instanceof Error ? err.message : "Error occurred while validating task.json");
+			const warningMessage = "Please, make sure the task.json file is correct. In the future, this warning will be treated as an error.\n";
+			trace.warn(err && err instanceof Error
+				? warningMessage + err.message
+				: "Error occurred while validating task.json");
 		}
 	}
 }

--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -1,10 +1,12 @@
-import { defer } from "./promiseUtils";
-
 var fs = require("fs");
 var check = require("validator");
 var trace = require("./trace");
 
 const deprecatedRunners = ["Node6", "Node10", "Node16"];
+
+export interface TaskJson {
+	id: string;
+}
 
 /*
  * Checks a json file for correct formatting against some validation function
@@ -13,9 +15,8 @@ const deprecatedRunners = ["Node6", "Node10", "Node16"];
  * @return the parsed json file
  * @throws InvalidDirectoryException if json file doesn't exist, InvalidJsonException on failed parse or *first* invalid field in json
 */
-export function validate(jsonFilePath: string, jsonMissingErrorMessage?: string): Promise<any> {
+export function validate(jsonFilePath: string, jsonMissingErrorMessage?: string): TaskJson {
 	trace.debug("Validating task json...");
-	var deferred = defer<any>();
 	var jsonMissingErrorMsg: string = jsonMissingErrorMessage || "specified json file does not exist.";
 	this.exists(jsonFilePath, jsonMissingErrorMsg);
 
@@ -34,13 +35,12 @@ export function validate(jsonFilePath: string, jsonMissingErrorMessage?: string)
 			output += "\n\t" + issues[i];
 		}
 		trace.debug(output);
-		deferred.reject(new Error(output));
+		throw new Error(output);
 	}
 
 	trace.debug("Json is valid.");
 	validateRunner(taskJson);
-	deferred.resolve(taskJson);
-	return <any>deferred.promise;
+	return taskJson;
 }
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**WI**
[AB#2221223](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2221223)

**Description**

This pull request adds the `task.json` validation for the `tfx extension create` command. If the file does not adhere to the [schema](https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json), the command will output a warning message.

**Examples**

- When the task name in `task.json` contains a wrong symbol:

    ![image](https://github.com/user-attachments/assets/8a4fab1f-9ddb-4910-b3d2-487e2c0d296f)

- When there are no validation errors, no warnings are displayed:
    
    ![image](https://github.com/user-attachments/assets/577cab75-0195-4554-9594-3cef1cf12737)


 