### PR TITLE
Upgrade clipboardy to patch vulnerability in cross-spawn

### DIFF
--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -688,7 +688,7 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 				case "clip":
 				case "clipboard":
 					let clipboardText = this.getClipboardOutput(data);
-					return clipboardy.write(clipboardText);
+					return clipboardy.default.write(clipboardText);
 				default:
 					return fsUtils.canWriteTo(path.resolve(outputDestination)).then(canWrite => {
 						if (canWrite) {

--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -688,7 +688,7 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 				case "clip":
 				case "clipboard":
 					let clipboardText = this.getClipboardOutput(data);
-					return clipboardy.default.write(clipboardText);
+					return clipboardy.default.writeSync(clipboardText);
 				default:
 					return fsUtils.canWriteTo(path.resolve(outputDestination)).then(canWrite => {
 						if (canWrite) {

--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -10,7 +10,7 @@ import args = require("./arguments");
 import { blue, cyan, gray, green, yellow, magenta, reset as resetColors, stripColors } from "colors";
 import command = require("../lib/command");
 import common = require("./common");
-import clipboardy = require("clipboardy");
+import clipboardy from "clipboardy";
 import { writeFile } from "fs";
 import loader = require("../lib/loader");
 import path = require("path");
@@ -688,7 +688,7 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 				case "clip":
 				case "clipboard":
 					let clipboardText = this.getClipboardOutput(data);
-					return clipboardy.default.writeSync(clipboardText);
+					return clipboardy.writeSync(clipboardText);
 				default:
 					return fsUtils.canWriteTo(path.resolve(outputDestination)).then(canWrite => {
 						if (canWrite) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tfx-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tfx-cli",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "app-root-path": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,136 +1,203 @@
 {
   "name": "tfx-cli",
   "version": "0.18.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@colors/colors": {
+  "packages": {
+    "": {
+      "name": "tfx-cli",
+      "version": "0.18.0",
+      "license": "MIT",
+      "dependencies": {
+        "app-root-path": "1.0.0",
+        "archiver": "2.0.3",
+        "azure-devops-node-api": "^10.2.2",
+        "clipboardy": "^4.0.0",
+        "colors": "~1.3.0",
+        "glob": "7.1.2",
+        "jju": "^1.4.0",
+        "json-in-place": "^1.0.1",
+        "jszip": "^3.10.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "onecolor": "^2.5.0",
+        "os-homedir": "^1.0.1",
+        "prompt": "^1.3.0",
+        "read": "^1.0.6",
+        "shelljs": "^0.8.5",
+        "tmp": "0.0.26",
+        "tracer": "0.7.4",
+        "util.promisify": "^1.0.0",
+        "uuid": "^3.0.1",
+        "validator": "^13.7.0",
+        "winreg": "0.0.12",
+        "xml2js": "^0.5.0"
+      },
+      "bin": {
+        "tfx": "_build/tfx-cli.js"
+      },
+      "devDependencies": {
+        "@types/clipboardy": "~1.1.0",
+        "@types/glob": "^5.0.29",
+        "@types/jju": "^1.4.1",
+        "@types/jszip": "~3.1.2",
+        "@types/lodash": "~4.14.110",
+        "@types/mkdirp": "^1.0.2",
+        "@types/node": "8.10.66",
+        "@types/shelljs": "^0.8.11",
+        "@types/uuid": "^2.0.29",
+        "@types/validator": "^4.5.27",
+        "@types/winreg": "^1.2.29",
+        "@types/xml2js": "0.0.27",
+        "ncp": "^2.0.0",
+        "rimraf": "^2.6.1",
+        "typescript": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k="
+      "integrity": "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
-    "@types/clipboardy": {
+    "node_modules/@types/clipboardy": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/clipboardy/-/clipboardy-1.1.0.tgz",
       "integrity": "sha1-MW/ho+1xsaUb7Lkl5+BJeYbGqFw=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/glob": {
+    "node_modules/@types/glob": {
       "version": "5.0.38",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/glob/-/glob-5.0.38.tgz",
       "integrity": "sha1-IOKfPGMy9rMynzRxHrsxoD3XSlE=",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/minimatch": "*",
         "@types/node": "*"
       }
     },
-    "@types/jju": {
+    "node_modules/@types/jju": {
       "version": "1.4.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/jju/-/jju-1.4.5.tgz",
       "integrity": "sha1-USzic1lLjQJbfrkClljgQa+WMbQ=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/jszip": {
+    "node_modules/@types/jszip": {
       "version": "3.1.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/jszip/-/jszip-3.1.7.tgz",
       "integrity": "sha1-xFvXK0SLP7ACElKCxXw2GQJHyzQ=",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
+    "node_modules/@types/lodash": {
       "version": "4.14.110",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/lodash/-/lodash-4.14.110.tgz",
       "integrity": "sha1-+wdJj4QVKUfzDqCdiSB8oHEjRh4=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/minimatch": {
+    "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha1-B1CLRXl8uB7D8nMBGwVM0HVe3co=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/mkdirp": {
+    "node_modules/@types/mkdirp": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/mkdirp/-/mkdirp-1.0.2.tgz",
       "integrity": "sha1-jQuteqeTq+VRhgvh965/MZjBZmY=",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "8.10.66",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-8.10.66.tgz",
       "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/shelljs": {
+    "node_modules/@types/shelljs": {
       "version": "0.8.15",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/shelljs/-/shelljs-0.8.15.tgz",
       "integrity": "sha1-Isarnf4FzsV9jmyxqV6hc67p/Kw=",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/glob": "~7.2.0",
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/glob": {
-          "version": "7.2.0",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "*",
-            "@types/node": "*"
-          }
-        }
       }
     },
-    "@types/uuid": {
+    "node_modules/@types/shelljs/node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/uuid": {
       "version": "2.0.35",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-2.0.35.tgz",
       "integrity": "sha1-ZpvNj8bzOHss2n/8QrNVZgWagMg=",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/validator": {
+    "node_modules/@types/validator": {
       "version": "4.5.29",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/validator/-/validator-4.5.29.tgz",
       "integrity": "sha1-R3/qhLcwCcHxPOYq7AU1leIiW+k=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/winreg": {
+    "node_modules/@types/winreg": {
       "version": "1.2.36",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/winreg/-/winreg-1.2.36.tgz",
       "integrity": "sha1-8dmpkYyukKY8YQbJgiSspqNpg/w=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "@types/xml2js": {
+    "node_modules/@types/xml2js": {
       "version": "0.0.27",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/xml2js/-/xml2js-0.0.27.tgz",
       "integrity": "sha1-5a01i5UNhH2wPl6jihr4c2vR78c=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
-    "app-root-path": {
+    "node_modules/app-root-path": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/app-root-path/-/app-root-path-1.0.0.tgz",
-      "integrity": "sha1-LHKZF0vGHLhv46SnmOAeSTt9U30="
+      "integrity": "sha1-LHKZF0vGHLhv46SnmOAeSTt9U30=",
+      "license": "MIT"
     },
-    "arch": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha1-G8R4GPMFdk8jqzMGsL/AhsWinRE="
-    },
-    "archiver": {
+    "node_modules/archiver": {
       "version": "2.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver/-/archiver-2.0.3.tgz",
       "integrity": "sha1-tDYLtYSvFDeZGUJxbyHXxSPR270=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "archiver-utils": "^1.3.0",
         "async": "^2.0.0",
         "buffer-crc32": "^0.2.1",
@@ -140,35 +207,50 @@
         "tar-stream": "^1.5.0",
         "walkdir": "^0.0.11",
         "zip-stream": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
-    "archiver-utils": {
+    "node_modules/archiver-utils": {
       "version": "1.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver-utils/-/archiver-utils-1.3.0.tgz",
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "glob": "^7.0.0",
         "graceful-fs": "^4.1.0",
         "lazystream": "^1.0.0",
         "lodash": "^4.8.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "array-buffer-byte-length": {
+    "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha1-HlWD7BZ2NUCieuUu7Zn/iZIjVo8=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "array.prototype.reduce": {
+    "node_modules/array.prototype.reduce": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/array.prototype.reduce/-/array.prototype.reduce-1.0.7.tgz",
       "integrity": "sha1-aq3C+ZWvKcuIfrhm2YHchatvfcc=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-abstract": "^1.23.2",
@@ -176,13 +258,20 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0",
         "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "arraybuffer.prototype.slice": {
+    "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha1-CXly9CVeQbw0JeN9w/ZCHPmu/eY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -191,245 +280,380 @@
         "get-intrinsic": "^1.2.3",
         "is-array-buffer": "^3.0.4",
         "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "async": {
+    "node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-2.6.4.tgz",
       "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "lodash": "^4.17.14"
       }
     },
-    "available-typed-arrays": {
+    "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "azure-devops-node-api": {
+    "node_modules/azure-devops-node-api": {
       "version": "10.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
       "integrity": "sha1-n1V+Yi3Qe7qpvV5+hOF8dh4hUbI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.4"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "license": "MIT"
     },
-    "base64-js": {
+    "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
-    "bl": {
+    "node_modules/bl": {
       "version": "1.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-1.2.3.tgz",
       "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer": {
+    "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
-      "requires": {
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
-    "buffer-alloc": {
+    "node_modules/buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
       }
     },
-    "buffer-alloc-unsafe": {
+    "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA="
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
+      "license": "MIT"
     },
-    "buffer-crc32": {
+    "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
-    "buffer-fill": {
+    "node_modules/buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "license": "MIT"
     },
-    "call-bind": {
+    "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha1-BgFlmcQMVkmMGHadJzC+JCtvo7k=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "clipboardy": {
-      "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha1-BSY2G/eHJMHyC+JI1CjjZUM8B+8=",
-      "requires": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
+    "node_modules/clipboardy": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha1-5zztk6dtGd03nr8fKXVlQm3/3KE=",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "colors": {
+    "node_modules/colors": {
       "version": "1.3.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha1-OeAF1Uav4B4B+cTKj6UPaGoBIF0="
+      "integrity": "sha1-OeAF1Uav4B4B+cTKj6UPaGoBIF0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
-    "compress-commons": {
+    "node_modules/compress-commons": {
       "version": "1.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/compress-commons/-/compress-commons-1.2.2.tgz",
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "buffer-crc32": "^0.2.1",
         "crc32-stream": "^2.0.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "license": "MIT"
     },
-    "core-util-is": {
+    "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
+      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
+      "license": "MIT"
     },
-    "crc": {
+    "node_modules/crc": {
       "version": "3.8.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc/-/crc-3.8.0.tgz",
       "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "buffer": "^5.1.0"
       }
     },
-    "crc32-stream": {
+    "node_modules/crc32-stream": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc32-stream/-/crc32-stream-2.0.0.tgz",
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "cycle": {
+    "node_modules/cycle": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "data-view-buffer": {
+    "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha1-jqYybv7Bei5CYgaW5nHX1ai8ZrI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "data-view-byte-length": {
+    "node_modules/data-view-byte-length": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha1-kHIcqV/ygGd+t5N0n84QETR2aeI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "data-view-byte-offset": {
+    "node_modules/data-view-byte-offset": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha1-Xgu/tIKO0tG5tADNin0Rm8oP8Yo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "dateformat": {
+    "node_modules/dateformat": {
       "version": "1.0.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dateformat/-/dateformat-1.0.11.tgz",
       "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
-      "requires": {
+      "dependencies": {
         "get-stdin": "*",
         "meow": "*"
+      },
+      "bin": {
+        "dateformat": "bin/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "define-data-property": {
+    "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "define-properties": {
+    "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "end-of-stream": {
+    "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "once": "^1.4.0"
       }
     },
-    "es-abstract": {
+    "node_modules/es-abstract": {
       "version": "1.23.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha1-jwxaNc0hUxJXPFonyH39bIgaCqA=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
         "available-typed-arrays": "^1.0.7",
@@ -476,529 +700,963 @@
         "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "es-array-method-boxes-properly": {
+    "node_modules/es-array-method-boxes-properly": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha1-hz8+hEGN5O4Zxb51KZCy5EcY0J4="
+      "integrity": "sha1-hz8+hEGN5O4Zxb51KZCy5EcY0J4=",
+      "license": "MIT"
     },
-    "es-define-property": {
+    "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha1-x/rvvf+LJpbPX0aSHt+3fMS6OEU=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "es-errors": {
+    "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8="
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "es-object-atoms": {
+    "node_modules/es-object-atoms": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "es-set-tostringtag": {
+    "node_modules/es-set-tostringtag": {
       "version": "2.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha1-i7YPCkQMLkKBliQoQ41YVFrzl3c=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "es-to-primitive": {
+    "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "execa": {
-      "version": "0.8.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-0.8.0.tgz",
-      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha1-UfallDtYD5Y8PKnGMheW24zDm4w=",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "eyes": {
+    "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+      "engines": {
+        "node": "> 0.1.90"
+      }
     },
-    "for-each": {
+    "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-callable": "^1.1.3"
       }
     },
-    "fs-constants": {
+    "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "license": "MIT"
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "license": "ISC"
     },
-    "function-bind": {
+    "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw="
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "function.prototype.name": {
+    "node_modules/function.prototype.name": {
       "version": "1.1.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha1-zfMVt9kO53pMbuIWw8M2LaB1M/0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
         "es-abstract": "^1.22.1",
         "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "functions-have-names": {
+    "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ="
+      "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "get-intrinsic": {
+    "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha1-44X1pLUifUScPqu60FSU7wq76t0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "get-stdin": {
+    "node_modules/get-stdin": {
       "version": "9.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stdin/-/get-stdin-9.0.0.tgz",
-      "integrity": "sha1-OYP/guA9VvGy6g0+YDJfOdcDpXU="
+      "integrity": "sha1-OYP/guA9VvGy6g0+YDJfOdcDpXU=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha1-3vnf1xdCzXdUp3Ye1DdJon0C7KI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "get-symbol-description": {
+    "node_modules/get-symbol-description": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha1-UzdE1aogrKTgecjl2vf9RCAoIfU=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-      "requires": {
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "globalthis": {
+    "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha1-dDDtOpddl7+1m8zkH1yruvplEjY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "gopd": {
+    "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "graceful-fs": {
+    "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM="
+      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
+      "license": "ISC"
     },
-    "has-bigints": {
+    "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo="
+      "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "has-property-descriptors": {
+    "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "has-proto": {
+    "node_modules/has-proto": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0="
+      "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "has-symbols": {
+    "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg="
+      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "has-tostringtag": {
+    "node_modules/has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "hasown": {
+    "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "ieee754": {
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha1-QmZaKE+a4NreO6QevDfrS4UvOig=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
-    "immediate": {
+    "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "license": "MIT"
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "license": "ISC"
     },
-    "internal-slot": {
+    "node_modules/internal-slot": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha1-wG3Mo+2HQkmIEAewpVI7FyoZCAI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
-    "is-array-buffer": {
+    "node_modules/is-array-buffer": {
       "version": "3.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha1-eh+Ss9Ye3SvGXSTxMFMOqT1/rpg=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-bigint": {
+    "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-boolean-object": {
+    "node_modules/is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-callable": {
+    "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU="
+      "integrity": "sha1-O8KoXqdC2eNiBdys3XLKH9xRsFU=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "is-core-module": {
+    "node_modules/is-core-module": {
       "version": "2.15.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha1-pzY6Jb7pQv76sN4Tv2qjcsgtzDc=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-data-view": {
+    "node_modules/is-data-view": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha1-S006URtw89wm1CwDypylFdhHdZ8=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-date-object": {
+    "node_modules/is-date-object": {
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-negative-zero": {
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c="
+      "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "is-number-object": {
+    "node_modules/is-number-object": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-regex": {
+    "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-shared-array-buffer": {
+    "node_modules/is-shared-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha1-Ejfxy6BZzbYkMdN43MN9loAYFog=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha1-5r/XqmvvafT0cs6btoHj5XtDGaw=",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "is-string": {
+    "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-symbol": {
+    "node_modules/is-symbol": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-typed-array": {
+    "node_modules/is-typed-array": {
       "version": "1.1.13",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha1-1sXKVt9iM0lZMi19fdHMpQ3r4ik=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-weakref": {
+    "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "isarray": {
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I=",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is64bit": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is64bit/-/is64bit-2.0.0.tgz",
+      "integrity": "sha1-GYxifLyxmLvsQCJR+I5eGlEjbAc=",
+      "license": "MIT",
+      "dependencies": {
+        "system-architecture": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "license": "MIT"
     },
-    "isexe": {
+    "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "license": "ISC"
     },
-    "isstream": {
+    "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "license": "MIT"
     },
-    "jju": {
+    "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
+      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
+      "license": "MIT"
     },
-    "json-in-place": {
+    "node_modules/json-in-place": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-in-place/-/json-in-place-1.0.1.tgz",
       "integrity": "sha1-ih7NJaac4ZAFUs1xUr2TdU3k4fA=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "json-lexer": "1.1.1"
       }
     },
-    "json-lexer": {
+    "node_modules/json-lexer": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-lexer/-/json-lexer-1.1.1.tgz",
-      "integrity": "sha1-vT7V1+Vgudma0iNPKMpwb7N3t9Q="
+      "integrity": "sha1-vT7V1+Vgudma0iNPKMpwb7N3t9Q=",
+      "license": "ISC"
     },
-    "jszip": {
+    "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha1-NK7nDrGOofrsL1iSCKFX0f6wkcI=",
-      "requires": {
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
       }
     },
-    "lazystream": {
+    "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha1-SUyDEGLx+UCCUexE2xy6KSQqJjg=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
       }
     },
-    "lie": {
+    "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lie/-/lie-3.3.0.tgz",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "immediate": "~3.0.5"
       }
     },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+      "license": "MIT"
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "meow": {
+    "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha1-a31j+RP5hAY7PMJhtuiADEzTR08="
+      "integrity": "sha1-a31j+RP5hAY7PMJhtuiADEzTR08=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "minimatch": {
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha1-YKkFUNXLCyOcymXYk7GlOymHHsw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw="
+      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
+      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "mute-stream": {
+    "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
+      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
+      "license": "ISC"
     },
-    "ncp": {
+    "node_modules/ncp": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-      "dev": true
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
+      }
     },
-    "normalize-path": {
+    "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha1-4jNT0Ou5MX8XTpNBfkpNgtAknp8=",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "object-inspect": {
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha1-KVWI3DruZBVPh3rbnXgLgcVUvxg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha1-3qAIhGf7mR5nr0BYFHokgkowQ/8="
+      "integrity": "sha1-3qAIhGf7mR5nr0BYFHokgkowQ/8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "object-keys": {
+    "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "object.assign": {
+    "node_modules/object.assign": {
       "version": "4.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha1-OoM/mrf9uA/J6NIwDIA9IW2P27A=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "object.getownpropertydescriptors": {
+    "node_modules/object.getownpropertydescriptors": {
       "version": "2.1.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.8.tgz",
       "integrity": "sha1-Lx/gYG7Bp2WBVMzU9yhQT2lmeSM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "array.prototype.reduce": "^1.0.6",
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -1006,111 +1664,164 @@
         "es-object-atoms": "^1.0.0",
         "gopd": "^1.0.1",
         "safe-array-concat": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "onecolor": {
+    "node_modules/onecolor": {
       "version": "2.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onecolor/-/onecolor-2.5.0.tgz",
-      "integrity": "sha1-Ila2UdyAfBAfAK7b1JklxXpEMcE="
+      "integrity": "sha1-Ila2UdyAfBAfAK7b1JklxXpEMcE=",
+      "engines": {
+        "node": ">=0.4.8"
+      }
     },
-    "os-homedir": {
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha1-fCTBjtH9LpvKS9JoBqM2E8d9NLQ=",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "os-tmpdir": {
+    "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "pako": {
+    "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8="
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+      "license": "(MIT AND Zlib)"
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "path-parse": {
+    "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+      "license": "MIT"
     },
-    "possible-typed-array-names": {
+    "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha1-ibtjxvraLD6QrcSmR77us5zHv48="
+      "integrity": "sha1-ibtjxvraLD6QrcSmR77us5zHv48=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
-    "process-nextick-args": {
+    "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "license": "MIT"
     },
-    "prompt": {
+    "node_modules/prompt": {
       "version": "1.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/prompt/-/prompt-1.3.0.tgz",
       "integrity": "sha1-sfbUfLG2vu1PBmC0cPXT7BV6184=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@colors/colors": "1.5.0",
         "async": "3.2.3",
         "read": "1.0.x",
         "revalidator": "0.1.x",
         "winston": "2.x"
       },
-      "dependencies": {
-        "async": {
-          "version": "3.2.3",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-3.2.3.tgz",
-          "integrity": "sha1-rFPa/T9HIO6eihYGKPGOqR3xlsk="
-        }
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    "node_modules/prompt/node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-3.2.3.tgz",
+      "integrity": "sha1-rFPa/T9HIO6eihYGKPGOqR3xlsk=",
+      "license": "MIT"
     },
-    "qs": {
+    "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.13.0.tgz",
       "integrity": "sha1-bKO9WEOffiRWVXmJl3h7DYilGQY=",
-      "requires": {
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "read": {
+    "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
         "isarray": "~1.0.0",
@@ -1120,235 +1831,371 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "regexp.prototype.flags": {
+    "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha1-E49kSjNQ+YGoWMRPa7GmH/Wb4zQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
         "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "remove-trailing-separator": {
+    "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "license": "ISC"
     },
-    "resolve": {
+    "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "revalidator": {
+    "node_modules/revalidator": {
       "version": "0.1.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/revalidator/-/revalidator-0.1.8.tgz",
-      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+      "license": "Apache 2.0",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "glob": "^7.1.3"
       },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "safe-array-concat": {
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha1-gdd+4MTouGNjUifHISeN1STCDts=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM="
-        }
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "license": "MIT"
     },
-    "safe-regex-test": {
+    "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha1-pbTA8G4KtQ6iw5XBTYNxIykkw3c=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "sax": {
+    "node_modules/sax": {
       "version": "1.4.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha1-RMyJiDd/EmME07P8EBDHM7kp7w8="
+      "integrity": "sha1-RMyJiDd/EmME07P8EBDHM7kp7w8=",
+      "license": "ISC"
     },
-    "set-function-length": {
+    "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "set-function-name": {
+    "node_modules/set-function-name": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "setimmediate": {
+    "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "license": "MIT"
     },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "shelljs": {
+    "node_modules/shelljs": {
       "version": "0.8.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "requires": {
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "side-channel": {
+    "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha1-q9Jft80kuvRUZkBrEJa3gxySFfI=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4",
         "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk="
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
-    "stack-trace": {
+    "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
-    "string.prototype.trim": {
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string.prototype.trim": {
       "version": "1.2.9",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha1-tvoybXLSx4tt8C93Wcc/j2J0+qQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-abstract": "^1.23.0",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "string.prototype.trimend": {
+    "node_modules/string.prototype.trimend": {
       "version": "1.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha1-NlG4UTcZ6Kn0jefy93ZAsmZSsik=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "string.prototype.trimstart": {
+    "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha1-UolMMT+/8xiDUoCu1g/3Hr8SuP0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "supports-preserve-symlinks-flag": {
+    "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "tar-stream": {
+    "node_modules/system-architecture": {
+      "version": "0.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/system-architecture/-/system-architecture-0.1.0.tgz",
+      "integrity": "sha1-cQErOsFBQn2XxnxWvHkhr2v/Ei0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tar-stream": {
       "version": "1.6.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
         "end-of-stream": "^1.0.0",
@@ -1356,138 +2203,200 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "tinytim": {
+    "node_modules/tinytim": {
       "version": "0.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tinytim/-/tinytim-0.1.1.tgz",
-      "integrity": "sha1-yWih5VWa2VUyJO92J7qzTjyu+Kg="
+      "integrity": "sha1-yWih5VWa2VUyJO92J7qzTjyu+Kg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.2.0"
+      }
     },
-    "tmp": {
+    "node_modules/tmp": {
       "version": "0.0.26",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tmp/-/tmp-0.0.26.tgz",
       "integrity": "sha1-nvqCDOKhD4H4l5VVus4/FVJs4fI=",
-      "requires": {
+      "dependencies": {
         "os-tmpdir": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
-    "to-buffer": {
+    "node_modules/to-buffer": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA="
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
+      "license": "MIT"
     },
-    "tracer": {
+    "node_modules/tracer": {
       "version": "0.7.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tracer/-/tracer-0.7.4.tgz",
       "integrity": "sha1-d/oEN8+Ct2vNvNRLhHRHcuWeUlk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "colors": "1.0.3",
         "dateformat": "1.0.11",
         "tinytim": "0.1.1"
       },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        }
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "tunnel": {
+    "node_modules/tracer/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw="
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
-    "typed-array-buffer": {
+    "node_modules/typed-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha1-GGfF2Dsg/LXM8yZJ5eL8dCRHT/M=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "typed-array-byte-length": {
+    "node_modules/typed-array-byte-length": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha1-2Sly08/5mj+i52Wij83A8did7Gc=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "typed-array-byte-offset": {
+    "node_modules/typed-array-byte-offset": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha1-+eway5JZ85UJPkVn6zwopYDQIGM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "typed-array-length": {
+    "node_modules/typed-array-length": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha1-VxVSB8duZKNFdILf3BydHTxMc6M=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-proto": "^1.0.3",
         "is-typed-array": "^1.1.13",
         "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "typed-rest-client": {
+    "node_modules/typed-rest-client": {
       "version": "1.8.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
       "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "3.9.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha1-cPORCselHta+952ngAaQsZv3eLg=",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "unbox-primitive": {
+    "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "underscore": {
+    "node_modules/underscore": {
       "version": "1.13.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA="
+      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "license": "MIT"
     },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "license": "MIT"
     },
-    "util.promisify": {
+    "node_modules/util.promisify": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util.promisify/-/util.promisify-1.1.2.tgz",
       "integrity": "sha1-ArPbrbuABx7uTEOu1YdHr9/FFts=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
         "for-each": "^0.3.3",
@@ -1495,65 +2404,101 @@
         "has-symbols": "^1.0.3",
         "object.getownpropertydescriptors": "^2.1.6",
         "safe-array-concat": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
-    },
-    "validator": {
-      "version": "13.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha1-fXjna6hVBNo/7k/Rkis4WRTUs18="
-    },
-    "walkdir": {
-      "version": "0.0.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
-      "requires": {
-        "isexe": "^2.0.0"
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
-    "which-boxed-primitive": {
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha1-fXjna6hVBNo/7k/Rkis4WRTUs18=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "which-typed-array": {
+    "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha1-JkhZ6bEaZJs4i/qvT3Z98fd5s40=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "winreg": {
+    "node_modules/winreg": {
       "version": "0.0.12",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/winreg/-/winreg-0.0.12.tgz",
-      "integrity": "sha1-BxBVVLoanQiXklHRKUdb/64wBrc="
+      "integrity": "sha1-BxBVVLoanQiXklHRKUdb/64wBrc=",
+      "license": "BSD"
     },
-    "winston": {
+    "node_modules/winston": {
       "version": "2.4.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/winston/-/winston-2.4.7.tgz",
       "integrity": "sha1-V5H+COp+kNsJDxyzHvmPMlMQYvE=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "async": "^2.6.4",
         "colors": "1.0.x",
         "cycle": "1.0.x",
@@ -1561,52 +2506,69 @@
         "isstream": "0.1.x",
         "stack-trace": "0.0.x"
       },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        }
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "wrappy": {
+    "node_modules/winston/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "license": "ISC"
     },
-    "xml2js": {
+    "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha1-2UQGMfuy7YACA/rRBvJyT2LEk7c=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
-    "xmlbuilder": {
+    "node_modules/xmlbuilder": {
       "version": "11.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
+      "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
-    "xtend": {
+    "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "zip-stream": {
+    "node_modules/zip-stream": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/zip-stream/-/zip-stream-1.2.0.tgz",
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "archiver-utils": "^1.3.0",
         "compress-commons": "^1.2.0",
         "lodash": "^4.8.0",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "app-root-path": "1.0.0",
     "archiver": "2.0.3",
     "azure-devops-node-api": "^10.2.2",
-    "clipboardy": "~1.2.3",
+    "clipboardy": "^4.0.0",
     "colors": "~1.3.0",
     "glob": "7.1.2",
     "jju": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Upgrades clipboardy to 4.0.0 which has long patched the cross-spawn vulnerability.