### PR TITLE
Splitting CI and release pipeline for this tool 

### DIFF
--- a/.azure-pipelines/azure-pipeline.yml
+++ b/.azure-pipelines/azure-pipeline.yml
@@ -1,9 +1,13 @@
 # This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
 # This pipeline will be extended to the OneESPT template
+# CI and PR build script
+#
+# There should be no deep magic here. The developer experience and CI experience
+# must remain as close to one another as possible.
 
 trigger:
 - master
-- releases/*
+
 variables:
 - group: npm-tokens
 resources:
@@ -33,57 +37,14 @@ extends:
       - job: job
         templateContext:
           outputs:
-          - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
-            - output: pipelineArtifact
-              displayName: 'Publish tfx-cli package to pipeline artifacts'
-              targetPath: '$(Build.ArtifactStagingDirectory)'
-              artifactType: 'pipeline'
-              artifactName: 'tfx-cli-package'
+          - output: pipelineArtifact
+            displayName: 'Publish tfx-cli package to pipeline artifacts'
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactType: 'pipeline'
+            artifactName: 'tfx-cli-package'
         steps:
-        - checkout: self
-          clean: true
+        - template: /.azure-pipelines/common-steps.yml@self
 
-        - task: NodeTool@0
-          displayName: Use node 10
-          inputs:
-            versionSpec: "10.x"
-
-        - task: NpmAuthenticate@0
-          inputs:
-            workingFile: .npmrc
-
-        - script: npm i -g npm@6.14.12 --force
-          displayName: Use npm version 6.14.12
-
-        - bash: |
-            npm ci
-            npm run build
-          displayName: Build TFX CLI
-
-        - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
-          # For CI and Manual runs automatically publish packages
-          # The npm cli will replace ${NPM_TOKEN} with the contents of the NPM_TOKEN environment variable.
-          - bash: |
-              echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
-
-              npm publish --ignore-scripts
-              exit_status=$?
-              if [ $exit_status -eq 1 ]; then
-                  echo "##vso[task.logissue type=warning]Publishing TFX CLI was unsuccessful"
-                  echo "##vso[task.complete result=SucceededWithIssues;]"
-              fi
-
-              rm .npmrc
-            displayName: Publish TFX CLI to npm
-            env:
-              NPM_TOKEN: $(npm-automation.token)
-
-          # Generate a pipeline artifact so we can publish the package manually if there are issues with automation
-          - bash: |
-              npm pack
-              cp *.tgz '$(Build.ArtifactStagingDirectory)'
-            displayName: Run npm-pack and copy to ArtifactStagingDirectory
-        
         # Install node 16 for CodeQL 3000
         - task: NodeTool@0
           displayName: Use node 16

--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -1,0 +1,29 @@
+# Common steps template
+#
+# Things which happen regardless of CI, PR, or release builds
+steps:
+  - checkout: self
+    clean: true
+
+  - task: NodeTool@0
+    displayName: Use node 10
+    inputs:
+      versionSpec: "10.x"
+
+  - task: NpmAuthenticate@0
+    inputs:
+      workingFile: .npmrc
+
+  - script: npm i -g npm@6.14.12 --force
+    displayName: Use npm version 6.14.12
+
+  - bash: |
+      npm ci
+      npm run build
+    displayName: Build TFX CLI
+
+  # Generate a pipeline artifact so we can publish the package manually if there are issues with automation
+  - bash: |
+      npm pack
+      cp *.tgz '$(Build.ArtifactStagingDirectory)'
+    displayName: Run npm-pack and copy to ArtifactStagingDirectory

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -1,0 +1,71 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# This pipeline will be extended to the OneESPT template
+
+trigger: none
+
+variables:
+- group: npm-tokens
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
+    # featureFlags:
+      # autoBaseline: false
+    # sdl:
+    #   baseline:
+    #     baselineSet: default
+    #     baselineFile: $(Build.SourcesDirectory)/.gdn/.gdnbaselines
+    pool:
+      name: 1ES-ABTT-Shared-Pool
+      image: abtt-windows-2022
+      os: windows
+    stages:
+    - stage: stage
+      jobs:
+      - job: job
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish tfx-cli package to pipeline artifacts'
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactType: 'pipeline'
+            artifactName: 'tfx-cli-package'
+        steps:
+        - template: /.azure-pipelines/common-steps.yml@self
+
+        - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
+          # For CI and Manual runs automatically publish packages
+          - task: ManualValidation@0
+            inputs:
+              notifyUsers: # string. Required. Notify users. 
+              #instructions: # string. Instructions. 
+              #onTimeout: 'reject' # 'reject' | 'resume'. On timeout. Default: reject.
+
+          # The npm cli will replace ${NPM_TOKEN} with the contents of the NPM_TOKEN environment variable.
+          - bash: |
+              echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
+
+              npm publish --ignore-scripts
+              exit_status=$?
+              if [ $exit_status -eq 1 ]; then
+                  echo "##vso[task.logissue type=warning]Publishing TFX CLI was unsuccessful"
+                  echo "##vso[task.complete result=SucceededWithIssues;]"
+              fi
+
+              rm .npmrc
+            displayName: Publish TFX CLI to npm
+            env:
+              NPM_TOKEN: $(npm-automation.token)
+
+        # Install node 16 for CodeQL 3000
+        - task: NodeTool@0
+          displayName: Use node 16
+          inputs:
+            versionSpec: "16.x"

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -56,6 +56,7 @@ extends:
 
               rm .npmrc
             displayName: Publish TFX CLI to npm
+            condition: eq(variables['Build.SourceBranchName'], 'master')
             env:
               NPM_TOKEN: $(npm-automation.token)
 

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -16,18 +16,14 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-    # featureFlags:
-      # autoBaseline: false
-    # sdl:
-    #   baseline:
-    #     baselineSet: default
-    #     baselineFile: $(Build.SourcesDirectory)/.gdn/.gdnbaselines
+
     pool:
       name: 1ES-ABTT-Shared-Pool
       image: abtt-windows-2022
       os: windows
     stages:
-    - stage: stage
+    - stage: Build
+      displayName: build the tfx-cli npm package
       jobs:
       - job: job
         templateContext:
@@ -39,15 +35,14 @@ extends:
             artifactName: 'tfx-cli-package'
         steps:
         - template: /.azure-pipelines/common-steps.yml@self
-
+    - stage: Deploy
+      displayName: upload the package to npm
+      trigger: manual
+      jobs:
+      - job: deploy
+        steps:
         - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
-          # For CI and Manual runs automatically publish packages
-          - task: ManualValidation@0
-            inputs:
-              notifyUsers: # string. Required. Notify users. 
-              #instructions: # string. Instructions. 
-              #onTimeout: 'reject' # 'reject' | 'resume'. On timeout. Default: reject.
-
+          # Validate and publish packages
           # The npm cli will replace ${NPM_TOKEN} with the contents of the NPM_TOKEN environment variable.
           - bash: |
               echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -25,7 +25,7 @@ extends:
     - stage: Build
       displayName: build the tfx-cli npm package
       jobs:
-      - job: job
+      - job: build
         templateContext:
           outputs:
           - output: pipelineArtifact
@@ -35,11 +35,10 @@ extends:
             artifactName: 'tfx-cli-package'
         steps:
         - template: /.azure-pipelines/common-steps.yml@self
-    - stage: Deploy
-      displayName: upload the package to npm
-      trigger: manual
-      jobs:
+
       - job: deploy
+        displayName: upload the package to npm
+        trigger: manual
         steps:
         - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
           # Validate and publish packages


### PR DESCRIPTION
Splitting CI and release pipeline for this tool to make sure we can generate the package for testing via CI pipeline and check the package before uploading to npm. 