### PR TITLE
Update azure-devops-node-api to latest.

### DIFF
--- a/app/exec/extension/_lib/publish.ts
+++ b/app/exec/extension/_lib/publish.ts
@@ -361,7 +361,7 @@ export class PackagePublisher extends GalleryBase {
 			let publishPromise: Promise<GalleryInterfaces.PublishedExtension>;
 			if (extInfo && extInfo.published) {
 				trace.info("It is, %s the extension", colors.cyan("update").toString());
-				publishPromise = this.galleryClient.updateExtension(null, extPackage, extInfo.publisher, extInfo.id, this.settings.bypassScopeCheck).catch(errHandler.httpErr);
+				publishPromise = this.galleryClient.updateExtension(null, extPackage, extInfo.publisher, extInfo.id, undefined, undefined, this.settings.bypassScopeCheck).catch(errHandler.httpErr);
 			} else {
 				trace.info("It isn't, %s a new extension.", colors.cyan("create").toString());
 				publishPromise = this.galleryClient.createExtension(null, extPackage).catch(errHandler.httpErr);

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,12 +210,12 @@
       }
     },
     "azure-devops-node-api": {
-      "version": "13.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-13.0.0.tgz",
-      "integrity": "sha1-4u0r7i+Plky+as+JSFTXADPyPY4=",
+      "version": "14.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
+      "integrity": "sha1-7FOT3p+hRjmd6qtpBOQdoD7c4YA=",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.4"
+        "typed-rest-client": "2.1.0"
       }
     },
     "balanced-match": {
@@ -289,6 +289,24 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "clipboardy": {
@@ -417,6 +435,25 @@
         "object-keys": "^1.1.1"
       }
     },
+    "des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -484,12 +521,9 @@
       "integrity": "sha1-hz8+hEGN5O4Zxb51KZCy5EcY0J4="
     },
     "es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha1-x/rvvf+LJpbPX0aSHt+3fMS6OEU=",
-      "requires": {
-        "get-intrinsic": "^1.2.4"
-      }
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo="
     },
     "es-errors": {
       "version": "1.3.0",
@@ -497,9 +531,9 @@
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8="
     },
     "es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -583,15 +617,29 @@
       "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ="
     },
     "get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha1-44X1pLUifUScPqu60FSU7wq76t0=",
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -637,12 +685,9 @@
       }
     },
     "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE="
     },
     "graceful-fs": {
       "version": "4.2.11",
@@ -668,9 +713,9 @@
       "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0="
     },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg="
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg="
     },
     "has-tostringtag": {
       "version": "1.0.2",
@@ -869,6 +914,11 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jju/-/jju-1.4.0.tgz",
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
     },
+    "js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
+    },
     "json-in-place": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/json-in-place/-/json-in-place-1.0.1.tgz",
@@ -923,10 +973,20 @@
         "yallist": "^2.1.2"
       }
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k="
+    },
     "meow": {
       "version": "13.2.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/meow/-/meow-13.2.0.tgz",
       "integrity": "sha1-a31j+RP5hAY7PMJhtuiADEzTR08="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
     },
     "minimatch": {
       "version": "3.1.2",
@@ -974,9 +1034,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha1-3qAIhGf7mR5nr0BYFHokgkowQ/8="
+      "version": "1.13.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -1091,11 +1151,11 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "qs": {
-      "version": "6.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha1-bKO9WEOffiRWVXmJl3h7DYilGQY=",
+      "version": "6.14.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
       "requires": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       }
     },
     "read": {
@@ -1275,14 +1335,47 @@
       }
     },
     "side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha1-q9Jft80kuvRUZkBrEJa3gxySFfI=",
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
       "requires": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      }
+    },
+    "side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      }
+    },
+    "side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       }
     },
     "signal-exit": {
@@ -1294,6 +1387,14 @@
       "version": "0.0.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "string.prototype.trim": {
       "version": "1.2.9",
@@ -1447,11 +1548,13 @@
       }
     },
     "typed-rest-client": {
-      "version": "1.8.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
-      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
       "requires": {
-        "qs": "^6.9.1",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,9 @@
       }
     },
     "azure-devops-node-api": {
-      "version": "10.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-      "integrity": "sha1-n1V+Yi3Qe7qpvV5+hOF8dh4hUbI=",
+      "version": "11.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
+      "integrity": "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs=",
       "requires": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,9 @@
       }
     },
     "azure-devops-node-api": {
-      "version": "12.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
-      "integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
+      "version": "13.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-13.0.0.tgz",
+      "integrity": "sha1-4u0r7i+Plky+as+JSFTXADPyPY4=",
       "requires": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,9 @@
       }
     },
     "azure-devops-node-api": {
-      "version": "11.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
-      "integrity": "sha1-vwTtvvYDExF6BQdBXu1HkKQgrWs=",
+      "version": "12.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
       "requires": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "app-root-path": "1.0.0",
     "archiver": "2.0.3",
-    "azure-devops-node-api": "^11.0.0",
+    "azure-devops-node-api": "^12.0.0",
     "clipboardy": "~1.2.3",
     "colors": "~1.3.0",
     "glob": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "app-root-path": "1.0.0",
     "archiver": "2.0.3",
-    "azure-devops-node-api": "^13.0.0",
+    "azure-devops-node-api": "^14.0.0",
     "clipboardy": "~1.2.3",
     "colors": "~1.3.0",
     "glob": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "app-root-path": "1.0.0",
     "archiver": "2.0.3",
-    "azure-devops-node-api": "^10.2.2",
+    "azure-devops-node-api": "^11.0.0",
     "clipboardy": "~1.2.3",
     "colors": "~1.3.0",
     "glob": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "app-root-path": "1.0.0",
     "archiver": "2.0.3",
-    "azure-devops-node-api": "^12.0.0",
+    "azure-devops-node-api": "^13.0.0",
     "clipboardy": "~1.2.3",
     "colors": "~1.3.0",
     "glob": "7.1.2",


### PR DESCRIPTION
This PR incrementally updates the `azure-devops-node-api` package to the latest version over a series of four commits.

Only one `tsc`-detected incompatibility.