### PR TITLE
Add support for pre and post execution handlers and update version

### DIFF
--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -58,7 +58,7 @@ export function exists(path: string, errorMessage: string) {
 /*
  * Counts the number of non-deprecated runners in a task's execution configuration
  * @param taskData the parsed json file
- * @return number of valid (non-deprecated) runners, or 0 if no execution is defined
+ * @return the lowest number of valid (non-deprecated) runners across all execution handlers in the task, or 0 if no (prejob|postjob)execution is defined at all
  */
 function countValidRunners(taskData: any): number {
   if (taskData == undefined)


### PR DESCRIPTION
Introduce pre and post execution handlers to enhance functionality and update the version to 0.21.4.

Also inspects tasks prejobexecution and postjobexecution handlers and doesn't error out on tasks that *only* have pre and post handlers:

Example:
```
  "prejobexecution": {
    "Node": {
      "target": "preinstallcert.js",
      "argumentFormat": ""
    }
  },
  "postjobexecution": {
    "Node": {
      "target": "postinstallcert.js",
      "argumentFormat": ""
    },
  "execution": {
    "Node": {
      "target": "postinstallcert.js",
      "argumentFormat": ""
    }
  },
```

This pull request updates the runner validation logic in `jsonvalidate.ts` and bumps the package version. The main change is an enhancement to how valid runners are counted across multiple execution properties, which improves task validation accuracy.

Enhancements to runner validation:

* The `countValidRunners` function in `jsonvalidate.ts` now checks for valid (non-deprecated) runners across `execution`, `prejobexecution`, and `postjobexecution` properties, and returns the minimum count among them, rather than just checking `execution`. This ensures tasks are only considered valid if all relevant execution phases have valid runners.

General maintenance:

* The package version in `package.json` is incremented from `0.21.3` to `0.21.4` to reflect these changes.

Bug fix:

* Fixed a missing closing brace in the `validateTask` function in `jsonvalidate.ts`, ensuring the function is properly terminated.