### PR TITLE
Update glob dependency to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tfx-cli",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tfx-cli",
-      "version": "0.22.6",
+      "version": "0.22.7",
       "license": "MIT",
       "dependencies": {
         "app-root-path": "1.0.0",
@@ -14,7 +14,7 @@
         "azure-devops-node-api": "^14.0.0",
         "clipboardy": "^4.0.0",
         "colors": "~1.3.0",
-        "glob": "^11.0.3",
+        "glob": "^11.1.0",
         "jju": "^1.4.0",
         "json-in-place": "^1.0.1",
         "jszip": "^3.10.1",
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -1833,14 +1833,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha1-nYCH5tct2zxHB7HSd4+A6j6u/NY=",
-      "license": "ISC",
+      "version": "11.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha1-T4JlduTrmcfa04N5PS+fCPZ+UKY=",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -2759,10 +2759,10 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha1-z3oDFKFsTZq3OncwoOjjw1AtR6o=",
-      "license": "ISC",
+      "version": "10.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha1-5uYbmwwdyrEWtafRRY6LaunnOlU=",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -4930,7 +4930,7 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
       "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
       "requires": {
-        "glob": "^10.0.0",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.0",
         "is-stream": "^2.0.1",
         "lazystream": "^1.0.0",
@@ -4940,9 +4940,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "10.4.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-          "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+          "version": "10.5.0",
+          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^3.1.2",
@@ -5794,13 +5794,13 @@
       }
     },
     "glob": {
-      "version": "11.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha1-nYCH5tct2zxHB7HSd4+A6j6u/NY=",
+      "version": "11.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha1-T4JlduTrmcfa04N5PS+fCPZ+UKY=",
       "requires": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -6330,9 +6330,9 @@
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
     },
     "minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha1-z3oDFKFsTZq3OncwoOjjw1AtR6o=",
+      "version": "10.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha1-5uYbmwwdyrEWtafRRY6LaunnOlU=",
       "requires": {
         "@isaacs/brace-expansion": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tfx-cli",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "description": "CLI for Azure DevOps Services and Team Foundation Server",
   "repository": {
     "type": "git",
@@ -34,13 +34,18 @@
     "test:extension-server-integration": "npm run build:tests && mocha \"_tests/tests/extension-server-integration-tests.js\"",
     "test:extension-consolidated": "npm run test:extension-local && npm run test:extension-server-integration"
   },
+  "overrides": {
+    "archiver-utils": {
+      "glob": "^10.5.0"
+    }
+  },
   "dependencies": {
     "app-root-path": "1.0.0",
     "archiver": "^7.0.1",
     "azure-devops-node-api": "^14.0.0",
     "clipboardy": "^4.0.0",
     "colors": "~1.3.0",
-    "glob": "^11.0.3",
+    "glob": "^11.1.0",
     "jju": "^1.4.0",
     "json-in-place": "^1.0.1",
     "jszip": "^3.10.1",


### PR DESCRIPTION
[AB#2343967](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2343967)
[AB#2343966](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2343966)

The glob package is marked as vulnerable

Applying fixes as per recommendation
Updating package version to 11.1.0

For the archiver package we don't have a new version of the package available
So an override has been implemented.


Testing was done locally only with 
npm run build
npm run test
<img width="635" height="132" alt="image" src="https://github.com/user-attachments/assets/664c999b-a8d1-4712-81d3-7c10ed2a7d78" />



Verified fix by running npm audit locally
