### PR TITLE
perf: migrate to tinyclip from clipboardy

### DIFF
--- a/app/lib/tfcommand.ts
+++ b/app/lib/tfcommand.ts
@@ -18,7 +18,7 @@ import { promisify } from "util";
 import trace = require("./trace");
 import version = require("./version");
 import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBaseInterfaces";
-const clipboardyWrite = (data: string) => import('clipboardy').then(clipboardy => clipboardy.default.writeSync(data));
+const clipboardWrite = (data: string) => import('tinyclip').then(mod => mod.writeText(data));
 
 export interface CoreArguments {
 	[key: string]: args.Argument<any>;
@@ -733,7 +733,7 @@ export abstract class TfCommand<TArguments extends CoreArguments, TResult> {
 				case "clip":
 				case "clipboard":
 					let clipboardText = this.getClipboardOutput(data);
-					return clipboardyWrite(clipboardText);
+					return clipboardWrite(clipboardText);
 				default:
 					return fsUtils.canWriteTo(path.resolve(outputDestination)).then(canWrite => {
 						if (canWrite) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "app-root-path": "1.0.0",
     "archiver": "^7.0.1",
     "azure-devops-node-api": "^14.0.0",
-    "clipboardy": "^4.0.0",
     "colors": "~1.3.0",
     "glob": "^11.1.0",
     "jju": "^1.4.0",
@@ -57,6 +56,7 @@
     "prompt": "^1.3.0",
     "read": "^1.0.6",
     "shelljs": "^0.10.0",
+    "tinyclip": "^0.1.12",
     "tmp": "^0.2.4",
     "tracer": "0.7.4",
     "util.promisify": "^1.0.0",
@@ -66,7 +66,6 @@
     "xml2js": "^0.5.0"
   },
   "devDependencies": {
-    "@types/clipboardy": "~1.1.0",
     "@types/jju": "^1.4.1",
     "@types/jszip": "~3.1.2",
     "@types/lodash": "~4.14.110",


### PR DESCRIPTION
Tinyclip is [really lighter](https://npmx.dev/compare?packages=tinyclip,clipboardy) than clipboardy. This PR was made as part of the [e18e initiative](https://e18e.dev/).

I do not have the credentials required to access the registry, so someone will have to run `npm i` and commit to this branch