### PR TITLE
Add validation for duplicate task id/name in extension contributions …

### DIFF
--- a/app/exec/extension/_lib/merger.ts
+++ b/app/exec/extension/_lib/merger.ts
@@ -410,7 +410,13 @@ export class Merger {
 				return;
 			}
 
-			const allTaskJsonPaths: string[] = [];
+			interface ContributionTaskData {
+				contributionId: string;
+				taskJsonPath: string;
+				id: string;
+				name: string;
+			}
+			const allContributionTaskData: ContributionTaskData[] = [];
 
 			// For each build task contribution, look for task.json files and validate them
 			for (const contrib of buildTaskContributions) {
@@ -447,24 +453,45 @@ export class Merger {
 				// Validate task.json files for this contribution with backwards compatibility checking
 				if (contributionTaskJsonPaths.length > 0) {
 					trace.debug(`Validating ${contributionTaskJsonPaths.length} task.json files for contribution ${contrib.id || taskPath}`);
-					
+
 					for (const taskJsonPath of contributionTaskJsonPaths) {
-						validate(taskJsonPath, "no task.json in specified directory", contributionTaskJsonPaths);
+						const taskData = validate(taskJsonPath, "no task.json in specified directory", contributionTaskJsonPaths);
+						allContributionTaskData.push({
+							contributionId: contrib.id || taskPath,
+							taskJsonPath,
+							id: taskData.id,
+							name: taskData.name,
+						});
 					}
-					
-					// Also collect for global tracking if needed
-					allTaskJsonPaths.push(...contributionTaskJsonPaths);
 				} else {
 					trace.warn(`Build task contribution '${contrib.id || taskPath}' does not have a task.json file. Expected task.json in ${absoluteTaskPath} or its subdirectories.`);
 				}
 			}
 
-			if (allTaskJsonPaths.length === 0) {
+			if (allContributionTaskData.length === 0) {
 				trace.debug("No task.json files found in build task contributions");
 				return;
 			}
 
-			trace.debug(`Successfully validated ${allTaskJsonPaths.length} task.json files across ${buildTaskContributions.length} build task contributions`);
+			// Detect duplicate task id/name across different contributions.
+			// When two contributions reference task.json files with the same id and name,
+			// Azure DevOps silently ignores the second contribution during installation.
+			for (let i = 0; i < allContributionTaskData.length; i++) {
+				for (let j = i + 1; j < allContributionTaskData.length; j++) {
+					const a = allContributionTaskData[i];
+					const b = allContributionTaskData[j];
+					if (a.contributionId !== b.contributionId && a.id === b.id && a.name === b.name) {
+						trace.warn(
+							`Contributions '${a.contributionId}' (${a.taskJsonPath}) and '${b.contributionId}' (${b.taskJsonPath}) ` +
+							`both declare a task with id '${a.id}' and name '${a.name}'. ` +
+							`Azure DevOps will silently ignore the second contribution during installation. ` +
+							`Each contribution must reference a task.json with a unique id and name combination.`
+						);
+					}
+				}
+			}
+
+			trace.debug(`Successfully validated ${allContributionTaskData.length} task.json files across ${buildTaskContributions.length} build task contributions`);
 
 		} catch (err) {
 			const warningMessage = "Please, make sure the task.json file is correct. In the future, this warning will be treated as an error.\n";

--- a/app/lib/jsonvalidate.ts
+++ b/app/lib/jsonvalidate.ts
@@ -7,6 +7,7 @@ const deprecatedRunners = ["Node", "Node6", "Node10", "Node16"];
 
 export interface TaskJson {
   id: string;
+  name: string;
 }
 
 /*

--- a/tests/extension-local-tests.ts
+++ b/tests/extension-local-tests.ts
@@ -76,7 +76,7 @@ describe('Extension Commands - Local Tests', function() {
     });
 
     describe('Command Help and Hierarchy', function() {
-        
+
         it('should display extension command group help', function(done) {
             execAsyncWithLogging(`node "${tfxPath}" extension --help`, 'extension --help')
                 .then(({ stdout }) => {
@@ -176,13 +176,13 @@ describe('Extension Commands - Local Tests', function() {
         it('should create extension from basic sample', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'test-extension.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create basic sample')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
                     assert(cleanOutput.includes('Completed operation: create extension'), 'Should indicate successful creation');
                     assert(fs.existsSync(outputPath), 'Should create .vsix file');
-                    
+
                     const stats = fs.statSync(outputPath);
                     assert(stats.size > 0, 'Created .vsix file should not be empty');
                     done();
@@ -195,7 +195,7 @@ describe('Extension Commands - Local Tests', function() {
             if (!fs.existsSync(tempDir)) {
                 fs.mkdirSync(tempDir);
             }
-            
+
             const outputPath = path.join(__dirname, 'temp-extension-create.vsix');
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${tempDir}" --output-path "${outputPath}" --no-prompt`, 'extension create missing manifest')
                 .then(() => {
@@ -204,7 +204,7 @@ describe('Extension Commands - Local Tests', function() {
                 .catch((error) => {
                     const cleanOutput = stripColors(error.stderr || error.stdout || error.message);
                     assert(cleanOutput.includes('ENOENT') || cleanOutput.includes('vss-extension.json') || cleanOutput.includes('manifest') || cleanOutput.includes('no manifests found'), 'Should mention missing manifest file');
-                    
+
                     // Cleanup
                     try {
                         if (fs.existsSync(outputPath)) {
@@ -224,10 +224,10 @@ describe('Extension Commands - Local Tests', function() {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'override-test.vsix');
             const overrideFilePath = path.join(basicExtensionPath, 'test-overrides.json');
-            
+
             // Create temporary overrides file
             fs.writeFileSync(overrideFilePath, JSON.stringify({ version: "2.0.0" }, null, 2));
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --overrides-file "${overrideFilePath}"`, 'extension create with overrides')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -256,7 +256,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should handle --rev-version parameter', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'rev-version-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --rev-version`, 'extension create --rev-version')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -270,7 +270,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should handle --bypass-validation parameter', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'bypass-validation-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --bypass-validation`, 'extension create --bypass-validation')
                 .then(({ stdout }) => {
                     // With bypass validation, it might still fail due to other issues, but validation should be skipped
@@ -289,7 +289,7 @@ describe('Extension Commands - Local Tests', function() {
     });
 
     describe('Extension Global Arguments', function() {
-        
+
         it('should handle --no-color argument', function(done) {
             execAsyncWithLogging(`node "${tfxPath}" extension --help --no-color`, 'extension --help --no-color')
                 .then(({ stdout }) => {
@@ -305,7 +305,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should handle --trace-level argument', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'trace-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --trace-level debug`, 'extension create --trace-level debug')
                 .then(({ stdout, stderr }) => {
                     const cleanOutput = stripColors(stdout + stderr);
@@ -330,15 +330,15 @@ describe('Extension Commands - Local Tests', function() {
     });
 
     describe('Extension File Path Handling', function() {
-        
+
         it('should handle relative paths', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'relative-test.vsix');
-            
+
             // Change to the extension directory and use relative paths
             const oldCwd = process.cwd();
             process.chdir(basicExtensionPath);
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root . --output-path relative-test.vsix`, 'extension create relative path')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -356,7 +356,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should handle absolute paths', function(done) {
             const basicExtensionPath = path.resolve(samplesPath, 'basic-extension');
             const outputPath = path.resolve(basicExtensionPath, 'absolute-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create absolute path')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -369,11 +369,11 @@ describe('Extension Commands - Local Tests', function() {
     });
 
     describe('Extension Manifest Variations', function() {
-        
+
         it('should handle manifest-globs parameter', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'manifest-globs-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --manifest-globs "vss-extension.json"`, 'extension create --manifest-globs')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -657,13 +657,13 @@ describe('Extension Commands - Local Tests', function() {
             }
 
             const outputPath = path.join(complexExtensionPath, 'complex-extension.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${complexExtensionPath}" --output-path "${outputPath}"`, 'extension create complex')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
                     assert(cleanOutput.includes('Completed operation: create extension'), 'Should create complex extension');
                     assert(fs.existsSync(outputPath), 'Should create .vsix file for complex extension');
-                    
+
                     const stats = fs.statSync(outputPath);
                     assert(stats.size > 1000, 'Complex extension should be reasonably sized');
                     done();
@@ -674,7 +674,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should override publisher in manifest', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'publisher-override.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --publisher "test-publisher"`, 'extension create --publisher')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -688,7 +688,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should override extension-id in manifest', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'extension-id-override.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --extension-id "test-extension-id"`, 'extension create --extension-id')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -702,7 +702,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should support JSON output format for create command', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'json-output-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --json`, 'extension create --json')
                 .then(({ stdout }) => {
                     // With --json flag, output might be JSON formatted
@@ -768,7 +768,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should handle extension with missing files referenced in manifest', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'missing-files-test.vsix');
-            
+
             // This should still create the extension but might show warnings
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create missing files in manifest')
                 .then(({ stdout }) => {
@@ -797,7 +797,7 @@ describe('Extension Commands - Local Tests', function() {
             }
 
             const outputPath = path.join(taskExtensionPath, 'valid-task-extension.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${taskExtensionPath}" --output-path "${outputPath}"`, 'extension create task extension')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -817,7 +817,7 @@ describe('Extension Commands - Local Tests', function() {
             }
 
             const outputPath = path.join(taskExtensionPath, 'validated-task.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${taskExtensionPath}" --output-path "${outputPath}"`, 'extension create validated task')
                 .then(({ stdout }) => {
                     // Should validate task.json files without errors
@@ -837,7 +837,7 @@ describe('Extension Commands - Local Tests', function() {
             }
 
             const outputPath = path.join(taskExtensionPath, 'deprecated-runner.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${taskExtensionPath}" --output-path "${outputPath}"`, 'extension create deprecated runner')
                 .then(({ stdout }) => {
                     // Should still create extension despite warnings
@@ -856,7 +856,7 @@ describe('Extension Commands - Local Tests', function() {
             }
 
             const outputPath = path.join(taskExtensionPath, 'versioned-tasks.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${taskExtensionPath}" --output-path "${outputPath}"`, 'extension create versioned tasks')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -870,7 +870,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should warn about invalid task.json but still create extension', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'invalid-task-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create invalid task')
                 .then(({ stdout }) => {
                     // Should create extension despite task validation warnings
@@ -883,7 +883,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should warn about missing task.json file', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'missing-task-json.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create missing task json')
                 .then(({ stdout }) => {
                     // Should create extension despite missing task files
@@ -896,7 +896,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should warn about missing execution target file', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'missing-execution-file.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create missing execution file')
                 .then(({ stdout }) => {
                     // Should create extension despite warnings about missing execution files
@@ -909,7 +909,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should warn about invalid task name format', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'invalid-task-name.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create invalid task name')
                 .then(({ stdout }) => {
                     // Should create extension despite task name validation warnings
@@ -922,7 +922,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should warn about friendly name length', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'long-name-extension.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}" --no-prompt`, 'extension create long name')
                 .then(({ stdout, stderr }) => {
                     // Should create extension despite friendly name warnings
@@ -941,7 +941,7 @@ describe('Extension Commands - Local Tests', function() {
             }
 
             const outputPath = path.join(taskExtensionPath, 'contributions-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${taskExtensionPath}" --output-path "${outputPath}"`, 'extension create contributions test')
                 .then(({ stdout }) => {
                     // Should validate task directory structure
@@ -954,7 +954,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should handle extensions without task contributions', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'no-tasks-extension.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create no tasks')
                 .then(({ stdout }) => {
                     const cleanOutput = stripColors(stdout);
@@ -968,7 +968,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should validate required task fields', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'task-fields-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create task fields')
                 .then(({ stdout }) => {
                     // Should validate task field requirements
@@ -981,7 +981,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should validate task inputs structure', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'task-inputs-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create task inputs')
                 .then(({ stdout }) => {
                     // Should validate task inputs structure
@@ -994,7 +994,7 @@ describe('Extension Commands - Local Tests', function() {
         it('should validate execution targets exist', function(done) {
             const basicExtensionPath = path.join(samplesPath, 'basic-extension');
             const outputPath = path.join(basicExtensionPath, 'execution-targets-test.vsix');
-            
+
             execAsyncWithLogging(`node "${tfxPath}" extension create --root "${basicExtensionPath}" --output-path "${outputPath}"`, 'extension create execution targets')
                 .then(({ stdout }) => {
                     // Should validate execution target file existence
@@ -1002,6 +1002,158 @@ describe('Extension Commands - Local Tests', function() {
                     done();
                 })
                 .catch(done);
+        });
+    });
+
+    describe('Extension Task Validation - Duplicate Task Id/Name', function() {
+
+        /**
+         * When two contributions in the same extension each point to a task.json
+         * with the same `id` AND `name`, Azure DevOps silently ignores the second
+         * contribution at install time.  The merger should emit a warning so authors
+         * catch this before publishing.
+         *
+         * Sample layout (duplicate-task-extension):
+         *   TaskV0/task.json  →  id: a1b2c3d4-…  name: MySharedTask
+         *   TaskV1/task.json  →  id: a1b2c3d4-…  name: MySharedTask  (same!)
+         *   vss-extension.json contributions: my-task-v0 → TaskV0, my-task-v1 → TaskV1
+         */
+
+        it('should warn when two contributions share the same task id and name (CLI)', function(done) {
+            const samplePath = path.join(samplesPath, 'duplicate-task-extension');
+            if (!fs.existsSync(samplePath)) {
+                console.log('Skipping duplicate task id/name test - sample not found');
+                done();
+                return;
+            }
+
+            const outputPath = path.join(samplePath, 'duplicate-task-test.vsix');
+
+            execAsyncWithLogging(
+                `node "${tfxPath}" extension create --root "${samplePath}" --output-path "${outputPath}"`,
+                'extension create duplicate task id/name'
+            )
+                .then(({ stdout, stderr }) => {
+                    const combinedOutput = stripColors(stdout + stderr);
+                    assert(
+                        combinedOutput.includes('warning:') && combinedOutput.includes('MySharedTask'),
+                        'Should warn about duplicate task id/name across contributions. Output was:\n' + combinedOutput
+                    );
+                    assert(
+                        combinedOutput.includes('my-task-v0') || combinedOutput.includes('my-task-v1'),
+                        'Warning should mention the offending contribution ids. Output was:\n' + combinedOutput
+                    );
+                    // The extension should still be created — this is a warning, not an error
+                    assert(fs.existsSync(outputPath), 'Should still create .vsix file despite the duplicate task warning');
+                    done();
+                })
+                .catch(done)
+                .finally(() => {
+                    try { if (fs.existsSync(outputPath)) fs.unlinkSync(outputPath); } catch (e) { /* ignore */ }
+                });
+        });
+
+        it('should warn when two contributions share the same task id and name (Merger unit test)', function(done) {
+            const samplePath = path.join(samplesPath, 'duplicate-task-extension');
+            if (!fs.existsSync(samplePath)) {
+                console.log('Skipping duplicate task merger unit test - sample not found');
+                done();
+                return;
+            }
+
+            const mergerModulePath = path.resolve(__dirname, '../../_build/exec/extension/_lib/merger');
+            const traceModulePath = path.resolve(__dirname, '../../_build/lib/trace');
+            let MergerCtor: any;
+            let traceModule: any;
+            try {
+                MergerCtor = require(mergerModulePath).Merger || require(mergerModulePath).default;
+                traceModule = require(traceModulePath);
+            } catch (e) {
+                done(e);
+                return;
+            }
+
+            // Capture trace.warn calls
+            const warnings: string[] = [];
+            const originalWarn = traceModule.warn;
+            traceModule.warn = (...args: any[]) => {
+                warnings.push(args.map(String).join(' '));
+            };
+
+            const settings: any = {
+                root: samplePath,
+                manifests: [path.join(samplePath, 'vss-extension.json')],
+                noPrompt: true,
+            };
+
+            const merger = new MergerCtor(settings);
+            merger.merge()
+                .then(() => {
+                    const duplicateWarning = warnings.find(w =>
+                        w.includes('MySharedTask') &&
+                        (w.includes('my-task-v0') || w.includes('my-task-v1'))
+                    );
+                    assert(
+                        duplicateWarning !== undefined,
+                        'Merger should emit a warning about duplicate task id/name. Warnings captured:\n' + warnings.join('\n')
+                    );
+                })
+                .catch(done)
+                .finally(() => {
+                    traceModule.warn = originalWarn;
+                    done();
+                });
+        });
+
+        it('should NOT warn when two contributions have different task ids', function(done) {
+            const taskExtensionPath = path.join(samplesPath, 'task-extension');
+            if (!fs.existsSync(taskExtensionPath)) {
+                console.log('Skipping no-duplicate-warning test - sample not found');
+                done();
+                return;
+            }
+
+            const mergerModulePath = path.resolve(__dirname, '../../_build/exec/extension/_lib/merger');
+            const traceModulePath = path.resolve(__dirname, '../../_build/lib/trace');
+            let MergerCtor: any;
+            let traceModule: any;
+            try {
+                MergerCtor = require(mergerModulePath).Merger || require(mergerModulePath).default;
+                traceModule = require(traceModulePath);
+            } catch (e) {
+                done(e);
+                return;
+            }
+
+            // Capture trace.warn calls
+            const warnings: string[] = [];
+            const originalWarn = traceModule.warn;
+            traceModule.warn = (...args: any[]) => {
+                warnings.push(args.map(String).join(' '));
+            };
+
+            const settings: any = {
+                root: taskExtensionPath,
+                manifests: [path.join(taskExtensionPath, 'vss-extension.json')],
+                noPrompt: true,
+            };
+
+            const merger = new MergerCtor(settings);
+            merger.merge()
+                .then(() => {
+                    const duplicateWarning = warnings.find(w =>
+                        w.includes('silently ignore') || w.includes('unique id and name')
+                    );
+                    assert(
+                        duplicateWarning === undefined,
+                        'Should NOT warn about duplicate task id/name when contributions use distinct task ids. Warnings captured:\n' + warnings.join('\n')
+                    );
+                })
+                .catch(done)
+                .finally(() => {
+                    traceModule.warn = originalWarn;
+                    done();
+                });
         });
     });
 });

--- a/tests/extension-samples/duplicate-task-extension/TaskV0/index.js
+++ b/tests/extension-samples/duplicate-task-extension/TaskV0/index.js
@@ -1,0 +1,1 @@
+console.log("TaskV0 running");

--- a/tests/extension-samples/duplicate-task-extension/TaskV0/task.json
+++ b/tests/extension-samples/duplicate-task-extension/TaskV0/task.json
@@ -1,0 +1,30 @@
+{
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "name": "MySharedTask",
+    "friendlyName": "My Shared Task V0",
+    "description": "Version 0 of a task that shares its id and name with another contribution",
+    "helpMarkDown": "",
+    "category": "Utility",
+    "author": "Test Publisher",
+    "version": {
+        "Major": 0,
+        "Minor": 1,
+        "Patch": 0
+    },
+    "instanceNameFormat": "My Shared Task $(message)",
+    "inputs": [
+        {
+            "name": "message",
+            "type": "string",
+            "label": "Message",
+            "defaultValue": "Hello",
+            "required": true,
+            "helpMarkDown": "The message to display"
+        }
+    ],
+    "execution": {
+        "Node20_1": {
+            "target": "index.js"
+        }
+    }
+}

--- a/tests/extension-samples/duplicate-task-extension/TaskV1/index.js
+++ b/tests/extension-samples/duplicate-task-extension/TaskV1/index.js
@@ -1,0 +1,1 @@
+console.log("TaskV1 running");

--- a/tests/extension-samples/duplicate-task-extension/TaskV1/task.json
+++ b/tests/extension-samples/duplicate-task-extension/TaskV1/task.json
@@ -1,0 +1,30 @@
+{
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "name": "MySharedTask",
+    "friendlyName": "My Shared Task V1",
+    "description": "Version 1 of a task that shares its id and name with another contribution - this causes Azure DevOps to silently drop the second contribution",
+    "helpMarkDown": "",
+    "category": "Utility",
+    "author": "Test Publisher",
+    "version": {
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0
+    },
+    "instanceNameFormat": "My Shared Task $(message)",
+    "inputs": [
+        {
+            "name": "message",
+            "type": "string",
+            "label": "Message",
+            "defaultValue": "Hello",
+            "required": true,
+            "helpMarkDown": "The message to display"
+        }
+    ],
+    "execution": {
+        "Node20_1": {
+            "target": "index.js"
+        }
+    }
+}

--- a/tests/extension-samples/duplicate-task-extension/vss-extension.json
+++ b/tests/extension-samples/duplicate-task-extension/vss-extension.json
@@ -1,0 +1,38 @@
+{
+    "manifestVersion": 1,
+    "id": "duplicate-task-extension",
+    "name": "Duplicate Task Extension",
+    "version": "1.0.0",
+    "publisher": "test-publisher",
+    "description": "An extension where two contributions point to task.json files that share the same id and name, triggering a duplicate-task warning",
+    "categories": [
+        "Azure Pipelines"
+    ],
+    "targets": [
+        {
+            "id": "Microsoft.VisualStudio.Services"
+        }
+    ],
+    "contributions": [
+        {
+            "id": "my-task-v0",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
+            "properties": {
+                "name": "TaskV0"
+            }
+        },
+        {
+            "id": "my-task-v1",
+            "type": "ms.vss-distributed-task.task",
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
+            "properties": {
+                "name": "TaskV1"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
…and enhance related tests

This pull request adds detection and warnings for duplicate task `id` and `name` combinations across build task contributions in Azure DevOps extensions. It ensures that extension authors are notified when two contributions reference tasks with the same `id` and `name`, which would otherwise cause Azure DevOps to silently ignore one of them. The PR also introduces comprehensive tests and a new sample extension to verify this behavior.

**Duplicate task detection and warning:**

* The `Merger` class in `merger.ts` now tracks both `id` and `name` for each task contribution and emits a warning if two different contributions reference tasks with the same `id` and `name`, alerting the author to a situation where Azure DevOps would silently drop one of the tasks. [[1]](diffhunk://#diff-251927ae79873b224cb15ab61cb6863f7e4ebb3334e9a602bf2ad90ec6a2f2b2L413-R419) [[2]](diffhunk://#diff-251927ae79873b224cb15ab61cb6863f7e4ebb3334e9a602bf2ad90ec6a2f2b2L452-R494)
* The `TaskJson` interface in `jsonvalidate.ts` is updated to require a `name` property, ensuring both `id` and `name` are available for duplicate detection.

**Testing and sample extension:**

* New tests are added to `extension-local-tests.ts` to verify that the warning is emitted when duplicate task `id`/`name` combinations are present, and that no warning is emitted when task `id`s are unique.
* A new sample extension, `duplicate-task-extension`, is added with two tasks (`TaskV0` and `TaskV1`) that intentionally share the same `id` and `name` to trigger and test the duplicate detection logic. [[1]](diffhunk://#diff-9ea4b82e67596ed6cac656d9eb5998d295d62e2a31f03ce3e4ba29e3d2eaa996R1-R30) [[2]](diffhunk://#diff-ddf67d7a35507bb4902f3b8c2f5b0afb3cfe1cc7e52a5384d7c04a9e109f9b43R1-R30) [[3]](diffhunk://#diff-6602550c2a4c62a0e1d09f66c684c8bc0497132541d138d9bd745357fc5c593cR1-R38) [[4]](diffhunk://#diff-5df334c79038b6fdf103bd4eb77ae715665609965c65bf0a436e51f95b8878f9R1) [[5]](diffhunk://#diff-42e3c2bb375742911532a72e335314712c4688b0bf5835a2278b5940f70b06f3R1)